### PR TITLE
Update performance workbook naming and sync to Drive

### DIFF
--- a/backend/app/routes/drive.py
+++ b/backend/app/routes/drive.py
@@ -778,13 +778,10 @@ async def generate_project_asset(
                 },
             ) from exc
 
-        update_info = await drive_service.update_performance_workbook(
-            project_id=project_id,
-            google_id=google_id,
-            content=result.content,
-        )
+        update_info_mapping = result.drive_update if isinstance(result.drive_update, Mapping) else None
+        update_info = dict(update_info_mapping) if update_info_mapping is not None else {}
 
-        file_id = update_info.get("fileId") if isinstance(update_info, dict) else None
+        file_id = update_info.get("fileId")
         if not file_id:
             raise HTTPException(status_code=500, detail="성능시험 파일을 업데이트하지 못했습니다. 다시 시도해 주세요.")
 

--- a/backend/app/services/excel_templates/performance_report.py
+++ b/backend/app/services/excel_templates/performance_report.py
@@ -23,6 +23,8 @@ WINDOWS_BASE_SHEET = "Windows #1"
 LINUX_BASE_SHEET = "Linux #1"
 WINDOWS_PREFIX = "Windows"
 LINUX_PREFIX = "Linux"
+MAX_SHEET_TITLE_LENGTH = 31
+INVALID_SHEET_CHARS = re.compile(r"[:\\/?*\[\]]")
 START_ROW = 4
 
 WINDOWS_RANGE_COLUMNS = {"A", "B", "C", "G", "H"}
@@ -41,6 +43,50 @@ class PerformanceWorkbookPayload:
     template_bytes: bytes
     windows_datasets: Sequence[PerformanceDataset]
     linux_datasets: Sequence[PerformanceDataset]
+
+
+def _sanitize_device_name(name: str) -> str:
+    sanitized = INVALID_SHEET_CHARS.sub(" ", name)
+    sanitized = sanitized.replace("'", "’")
+    sanitized = re.sub(r"\s+", " ", sanitized).strip()
+    if not sanitized:
+        return ""
+    return sanitized[:MAX_SHEET_TITLE_LENGTH]
+
+
+def _ensure_unique_sheet_title(base: str, used: Set[str]) -> str:
+    normalized = base.casefold()
+    if normalized not in used:
+        return base
+
+    counter = 2
+    while True:
+        suffix = f" ({counter})"
+        available = MAX_SHEET_TITLE_LENGTH - len(suffix)
+        truncated = base[:available].rstrip()
+        if not truncated:
+            truncated = base[:available]
+        candidate = f"{truncated}{suffix}"
+        normalized_candidate = candidate.casefold()
+        if normalized_candidate not in used:
+            return candidate
+        counter += 1
+
+
+def _build_sheet_titles(prefix: str, datasets: Sequence[PerformanceDataset]) -> List[str]:
+    used: Set[str] = set()
+    titles: List[str] = []
+
+    for index, dataset in enumerate(datasets, start=1):
+        raw_name = str(dataset.metadata.get("device_name") or "").strip()
+        base_title = _sanitize_device_name(raw_name)
+        if not base_title:
+            base_title = f"{prefix} #{index}"
+        unique_title = _ensure_unique_sheet_title(base_title, used)
+        used.add(unique_title.casefold())
+        titles.append(unique_title)
+
+    return titles
 
 
 def build_performance_workbook(payload: PerformanceWorkbookPayload) -> bytes:
@@ -134,8 +180,10 @@ class _PerformanceWorkbookManager:
                 pass
             workbook._sheets.insert(template_index + offset, sheet)  # type: ignore[attr-defined]
 
-        for index, worksheet in enumerate(new_sheets, start=1):
-            worksheet.title = f"{prefix} #{index}"
+        sheet_titles = _build_sheet_titles(prefix, datasets)
+
+        for worksheet, title in zip(new_sheets, sheet_titles):
+            worksheet.title = title
             worksheet._charts = []  # type: ignore[attr-defined]
             for chart in template_charts:
                 new_chart = deepcopy(chart)

--- a/backend/app/services/google_drive/service.py
+++ b/backend/app/services/google_drive/service.py
@@ -851,6 +851,7 @@ class GoogleDriveService:
         google_id: Optional[str],
         content: bytes,
         file_id: Optional[str] = None,
+        file_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         resolved = await self._resolve_menu_spreadsheet(
             project_id=project_id,
@@ -860,17 +861,19 @@ class GoogleDriveService:
             file_id=file_id,
         )
 
+        target_name = file_name or resolved.file_name
+
         update_info, _ = await self._client.update_file_content(
             resolved.tokens,
             file_id=resolved.file_id,
-            file_name=resolved.file_name,
+            file_name=target_name,
             content=content,
             content_type=XLSX_MIME_TYPE,
         )
 
         return {
             "fileId": resolved.file_id,
-            "fileName": resolved.file_name,
+            "fileName": target_name,
             "modifiedTime": update_info.get("modifiedTime") if isinstance(update_info, dict) else None,
         }
 

--- a/backend/app/services/performance_report/service.py
+++ b/backend/app/services/performance_report/service.py
@@ -123,14 +123,18 @@ class PerformanceReportService:
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+        project_number = await self._drive_service.get_project_exam_number(
+            project_id=project_id,
+            google_id=google_id,
+        )
+        filename = f"{project_number} 성능시험 v1.0.xlsx"
+
         drive_update_info = await self._drive_service.update_performance_workbook(
             project_id=project_id,
             google_id=google_id,
             content=workbook_bytes,
+            file_name=filename,
         )
-
-        project_number = await self._drive_service.get_project_exam_number(project_id=project_id, google_id=google_id)
-        filename = f"{project_number} 성능시험 v1.0.xlsx"
 
         return PerformanceWorkbookResult(
             filename=filename,

--- a/backend/app/services/performance_report/service.py
+++ b/backend/app/services/performance_report/service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from fastapi import HTTPException, UploadFile
 
@@ -24,6 +24,7 @@ class PerformanceWorkbookResult:
     content: bytes
     datasets_by_os: Mapping[PerformanceOSType, Sequence[PerformanceDataset]]
     warnings: Sequence[str]
+    drive_update: Optional[Mapping[str, Any]] = None
 
 
 @dataclass
@@ -122,6 +123,12 @@ class PerformanceReportService:
         except RuntimeError as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
+        drive_update_info = await self._drive_service.update_performance_workbook(
+            project_id=project_id,
+            google_id=google_id,
+            content=workbook_bytes,
+        )
+
         project_number = await self._drive_service.get_project_exam_number(project_id=project_id, google_id=google_id)
         filename = f"{project_number} 성능시험 v1.0.xlsx"
 
@@ -130,6 +137,7 @@ class PerformanceReportService:
             content=workbook_bytes,
             datasets_by_os=datasets_by_os,
             warnings=warnings,
+            drive_update=drive_update_info,
         )
 
     async def _collect_uploads(self, uploads: Sequence[UploadFile]) -> List[Tuple[UploadFile, bytes]]:


### PR DESCRIPTION
## Summary
- derive performance workbook sheet titles from provided device names while keeping template chart references intact
- propagate generated performance reports to the Google Drive project spreadsheet and return the update metadata with the API response

## Testing
- pytest backend/tests/test_excel_population.py *(fails: expected security report order value differs from template output)*

------
https://chatgpt.com/codex/tasks/task_e_6908073b21188330bfee89f619479adc