### PR TITLE
Show background task tray count when idle

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -19,6 +19,190 @@
   backdrop-filter: blur(12px);
 }
 
+.app-shell__tasks {
+  margin-left: auto;
+  margin-right: 1.5rem;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.app-shell__tasks-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(226, 232, 240, 0.45);
+  background: rgba(15, 23, 42, 0.25);
+  color: rgba(226, 232, 240, 0.92);
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-shell__tasks-toggle:hover,
+.app-shell__tasks-toggle:focus-visible,
+.app-shell__tasks-toggle--open {
+  background: rgba(59, 130, 246, 0.22);
+  border-color: rgba(226, 232, 240, 0.75);
+  color: #ffffff;
+  box-shadow: 0 10px 24px rgba(30, 64, 175, 0.35);
+}
+
+.app-shell__tasks-toggle:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.85);
+  outline-offset: 2px;
+}
+
+.app-shell__tasks-count {
+  min-width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 999px;
+  background: rgba(248, 113, 113, 0.92);
+  color: #ffffff;
+  font-size: 0.82rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0.4rem;
+}
+
+.app-shell__tasks-panel {
+  position: absolute;
+  top: calc(100% + 0.75rem);
+  right: 0;
+  width: min(420px, 85vw);
+  max-height: 60vh;
+  padding: 1rem;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.96);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(18px);
+  overflow-y: auto;
+}
+
+.app-shell__tasks-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.app-shell__task {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem;
+  border-radius: 14px;
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.app-shell__task-main {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.app-shell__task-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-shell__task-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.65rem;
+  font-size: 0.82rem;
+  color: rgba(203, 213, 225, 0.92);
+}
+
+.app-shell__task-status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.app-shell__task-status-badge--running {
+  background: rgba(59, 130, 246, 0.3);
+  color: #bfdbfe;
+}
+
+.app-shell__task-status-badge--succeeded {
+  background: rgba(34, 197, 94, 0.28);
+  color: #bbf7d0;
+}
+
+.app-shell__task-status-badge--failed {
+  background: rgba(239, 68, 68, 0.28);
+  color: #fecaca;
+}
+
+.app-shell__task-message {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.app-shell__task-warning {
+  font-size: 0.8rem;
+  color: rgba(251, 191, 36, 0.95);
+}
+
+.app-shell__task-error {
+  font-size: 0.8rem;
+  color: rgba(248, 113, 113, 0.95);
+}
+
+.app-shell__task-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  align-items: flex-end;
+}
+
+.app-shell__task-button {
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.12);
+  color: #e2e8f0;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.app-shell__task-button:hover,
+.app-shell__task-button:focus-visible {
+  background: rgba(148, 163, 184, 0.24);
+  border-color: rgba(226, 232, 240, 0.75);
+  color: #ffffff;
+}
+
+.app-shell__task-button--dismiss {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.app-shell__task-button--dismiss:hover,
+.app-shell__task-button--dismiss:focus-visible {
+  background: rgba(248, 113, 113, 0.22);
+  border-color: rgba(248, 113, 113, 0.6);
+  color: #fee2e2;
+}
+
 .app-shell__brand {
   font-size: 1.25rem;
   font-weight: 700;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -149,6 +149,11 @@
   color: #fecaca;
 }
 
+.app-shell__task-status-badge--cancelled {
+  background: rgba(148, 163, 184, 0.28);
+  color: #e2e8f0;
+}
+
 .app-shell__task-message {
   font-size: 0.8rem;
   color: rgba(226, 232, 240, 0.85);

--- a/frontend/src/app/background/BackgroundTaskContext.tsx
+++ b/frontend/src/app/background/BackgroundTaskContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react'
 
-export type BackgroundTaskStatus = 'running' | 'succeeded' | 'failed'
+export type BackgroundTaskStatus = 'running' | 'succeeded' | 'failed' | 'cancelled'
 
 export type BackgroundTaskResult =
   | {
@@ -35,14 +35,17 @@ export interface BackgroundTask {
 
 export interface BackgroundTaskHandle {
   id: string
+  signal: AbortSignal
   update: (message: string | null) => void
   complete: (result: BackgroundTaskResult, message?: string | null) => void
   fail: (errorMessage: string | null) => void
+  onCancel: (callback: () => void) => () => void
 }
 
 interface BackgroundTaskContextValue {
   tasks: BackgroundTask[]
   startTask: (menuId: string, label: string) => BackgroundTaskHandle
+  cancelTask: (taskId: string) => void
   dismissTask: (taskId: string) => void
   getDownloadUrl: (taskId: string) => string | null
 }
@@ -60,6 +63,8 @@ export function BackgroundTaskProvider({ children }: PropsWithChildren) {
   const [tasks, setTasks] = useState<BackgroundTask[]>([])
   const tasksRef = useRef<BackgroundTask[]>(tasks)
   const downloadUrlMapRef = useRef<Map<string, string>>(new Map())
+  const cancelCallbacksRef = useRef<Map<string, Set<() => void>>>(new Map())
+  const abortControllerRef = useRef<Map<string, AbortController>>(new Map())
 
   useEffect(() => {
     tasksRef.current = tasks
@@ -75,66 +80,148 @@ export function BackgroundTaskProvider({ children }: PropsWithChildren) {
         }
       })
       downloadUrlMapRef.current.clear()
+      cancelCallbacksRef.current.clear()
+      abortControllerRef.current.clear()
     }
   }, [])
 
-  const startTask = useCallback((menuId: string, label: string): BackgroundTaskHandle => {
-    const id = createTaskId()
-    const timestamp = Date.now()
-    const task: BackgroundTask = {
-      id,
-      menuId,
-      label,
-      status: 'running',
-      message: null,
-      errorMessage: null,
-      result: null,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    }
+  const cleanupTaskResources = useCallback((taskId: string) => {
+    cancelCallbacksRef.current.delete(taskId)
+    abortControllerRef.current.delete(taskId)
+  }, [])
 
-    setTasks((prev) => [...prev, task])
+  const startTask = useCallback(
+    (menuId: string, label: string): BackgroundTaskHandle => {
+      const id = createTaskId()
+      const timestamp = Date.now()
+      const task: BackgroundTask = {
+        id,
+        menuId,
+        label,
+        status: 'running',
+        message: null,
+        errorMessage: null,
+        result: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }
 
-    const updateTask = (partial: Partial<Omit<BackgroundTask, 'id' | 'menuId' | 'label'>>) => {
+      setTasks((prev) => [...prev, task])
+
+      const abortController = new AbortController()
+      abortControllerRef.current.set(id, abortController)
+      cancelCallbacksRef.current.set(id, new Set())
+
+      const updateTask = (partial: Partial<Omit<BackgroundTask, 'id' | 'menuId' | 'label'>>) => {
+        setTasks((prev) =>
+          prev.map((entry) =>
+            entry.id === id
+              ? {
+                  ...entry,
+                  ...partial,
+                  updatedAt: Date.now(),
+                }
+              : entry,
+          ),
+        )
+      }
+
+      return {
+        id,
+        signal: abortController.signal,
+        update(message) {
+          updateTask({ message })
+        },
+        complete(result, message = null) {
+          if (abortController.signal.aborted) {
+            cleanupTaskResources(id)
+            return
+          }
+          updateTask({ status: 'succeeded', result, message, errorMessage: null })
+          cleanupTaskResources(id)
+        },
+        fail(errorMessage) {
+          if (abortController.signal.aborted) {
+            cleanupTaskResources(id)
+            return
+          }
+          updateTask({ status: 'failed', errorMessage, message: null })
+          cleanupTaskResources(id)
+        },
+        onCancel(callback) {
+          const callbacks = cancelCallbacksRef.current.get(id)
+          if (!callbacks) {
+            return () => {}
+          }
+          callbacks.add(callback)
+          return () => {
+            callbacks.delete(callback)
+          }
+        },
+      }
+    },
+    [cleanupTaskResources],
+  )
+
+  const dismissTask = useCallback(
+    (taskId: string) => {
+      cleanupTaskResources(taskId)
+      setTasks((prev) => prev.filter((task) => task.id !== taskId))
+      const url = downloadUrlMapRef.current.get(taskId)
+      if (url) {
+        try {
+          URL.revokeObjectURL(url)
+        } catch {
+          // ignore revoke errors
+        }
+        downloadUrlMapRef.current.delete(taskId)
+      }
+    },
+    [cleanupTaskResources],
+  )
+
+  const cancelTask = useCallback(
+    (taskId: string) => {
+      const task = tasksRef.current.find((entry) => entry.id === taskId)
+      if (!task || task.status !== 'running') {
+        dismissTask(taskId)
+        return
+      }
+
       setTasks((prev) =>
         prev.map((entry) =>
-          entry.id === id
+          entry.id === taskId
             ? {
                 ...entry,
-                ...partial,
+                status: 'cancelled',
+                message: '사용자에 의해 작업이 중단되었습니다.',
+                errorMessage: null,
                 updatedAt: Date.now(),
               }
             : entry,
         ),
       )
-    }
 
-    return {
-      id,
-      update(message) {
-        updateTask({ message })
-      },
-      complete(result, message = null) {
-        updateTask({ status: 'succeeded', result, message, errorMessage: null })
-      },
-      fail(errorMessage) {
-        updateTask({ status: 'failed', errorMessage, message: null })
-      },
-    }
-  }, [])
-
-  const dismissTask = useCallback((taskId: string) => {
-    setTasks((prev) => prev.filter((task) => task.id !== taskId))
-    const url = downloadUrlMapRef.current.get(taskId)
-    if (url) {
-      try {
-        URL.revokeObjectURL(url)
-      } catch {
-        // ignore revoke errors
+      const controller = abortControllerRef.current.get(taskId)
+      if (controller && !controller.signal.aborted) {
+        controller.abort()
       }
-      downloadUrlMapRef.current.delete(taskId)
-    }
-  }, [])
+
+      const callbacks = cancelCallbacksRef.current.get(taskId)
+      if (callbacks) {
+        callbacks.forEach((callback) => {
+          try {
+            callback()
+          } catch {
+            // ignore callback errors
+          }
+        })
+      }
+
+      cleanupTaskResources(taskId)
+    },
+    [cleanupTaskResources, dismissTask],
+  )
 
   const getDownloadUrl = useCallback(
     (taskId: string) => {
@@ -158,8 +245,8 @@ export function BackgroundTaskProvider({ children }: PropsWithChildren) {
   )
 
   const value = useMemo<BackgroundTaskContextValue>(
-    () => ({ tasks, startTask, dismissTask, getDownloadUrl }),
-    [tasks, startTask, dismissTask, getDownloadUrl],
+    () => ({ tasks, startTask, cancelTask, dismissTask, getDownloadUrl }),
+    [tasks, startTask, cancelTask, dismissTask, getDownloadUrl],
   )
 
   return <BackgroundTaskContext.Provider value={value}>{children}</BackgroundTaskContext.Provider>

--- a/frontend/src/app/background/BackgroundTaskContext.tsx
+++ b/frontend/src/app/background/BackgroundTaskContext.tsx
@@ -1,0 +1,174 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type PropsWithChildren } from 'react'
+
+export type BackgroundTaskStatus = 'running' | 'succeeded' | 'failed'
+
+export type BackgroundTaskResult =
+  | {
+      type: 'download'
+      blob: Blob
+      filename: string
+      contentType: string
+      warnings?: string[]
+    }
+  | {
+      type: 'navigate'
+      url: string
+      label?: string
+    }
+  | {
+      type: 'data'
+      payload: unknown
+    }
+  | null
+
+export interface BackgroundTask {
+  id: string
+  menuId: string
+  label: string
+  status: BackgroundTaskStatus
+  message: string | null
+  errorMessage: string | null
+  result: BackgroundTaskResult
+  createdAt: number
+  updatedAt: number
+}
+
+export interface BackgroundTaskHandle {
+  id: string
+  update: (message: string | null) => void
+  complete: (result: BackgroundTaskResult, message?: string | null) => void
+  fail: (errorMessage: string | null) => void
+}
+
+interface BackgroundTaskContextValue {
+  tasks: BackgroundTask[]
+  startTask: (menuId: string, label: string) => BackgroundTaskHandle
+  dismissTask: (taskId: string) => void
+  getDownloadUrl: (taskId: string) => string | null
+}
+
+const BackgroundTaskContext = createContext<BackgroundTaskContextValue | null>(null)
+
+function createTaskId(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+  return `task_${Math.random().toString(36).slice(2)}`
+}
+
+export function BackgroundTaskProvider({ children }: PropsWithChildren) {
+  const [tasks, setTasks] = useState<BackgroundTask[]>([])
+  const tasksRef = useRef<BackgroundTask[]>(tasks)
+  const downloadUrlMapRef = useRef<Map<string, string>>(new Map())
+
+  useEffect(() => {
+    tasksRef.current = tasks
+  }, [tasks])
+
+  useEffect(() => {
+    return () => {
+      downloadUrlMapRef.current.forEach((url) => {
+        try {
+          URL.revokeObjectURL(url)
+        } catch {
+          // ignore revoke errors
+        }
+      })
+      downloadUrlMapRef.current.clear()
+    }
+  }, [])
+
+  const startTask = useCallback((menuId: string, label: string): BackgroundTaskHandle => {
+    const id = createTaskId()
+    const timestamp = Date.now()
+    const task: BackgroundTask = {
+      id,
+      menuId,
+      label,
+      status: 'running',
+      message: null,
+      errorMessage: null,
+      result: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }
+
+    setTasks((prev) => [...prev, task])
+
+    const updateTask = (partial: Partial<Omit<BackgroundTask, 'id' | 'menuId' | 'label'>>) => {
+      setTasks((prev) =>
+        prev.map((entry) =>
+          entry.id === id
+            ? {
+                ...entry,
+                ...partial,
+                updatedAt: Date.now(),
+              }
+            : entry,
+        ),
+      )
+    }
+
+    return {
+      id,
+      update(message) {
+        updateTask({ message })
+      },
+      complete(result, message = null) {
+        updateTask({ status: 'succeeded', result, message, errorMessage: null })
+      },
+      fail(errorMessage) {
+        updateTask({ status: 'failed', errorMessage, message: null })
+      },
+    }
+  }, [])
+
+  const dismissTask = useCallback((taskId: string) => {
+    setTasks((prev) => prev.filter((task) => task.id !== taskId))
+    const url = downloadUrlMapRef.current.get(taskId)
+    if (url) {
+      try {
+        URL.revokeObjectURL(url)
+      } catch {
+        // ignore revoke errors
+      }
+      downloadUrlMapRef.current.delete(taskId)
+    }
+  }, [])
+
+  const getDownloadUrl = useCallback(
+    (taskId: string) => {
+      const existing = downloadUrlMapRef.current.get(taskId)
+      if (existing) {
+        return existing
+      }
+      const task = tasksRef.current.find((entry) => entry.id === taskId)
+      if (!task || task.result?.type !== 'download') {
+        return null
+      }
+      try {
+        const objectUrl = URL.createObjectURL(task.result.blob)
+        downloadUrlMapRef.current.set(taskId, objectUrl)
+        return objectUrl
+      } catch {
+        return null
+      }
+    },
+    [],
+  )
+
+  const value = useMemo<BackgroundTaskContextValue>(
+    () => ({ tasks, startTask, dismissTask, getDownloadUrl }),
+    [tasks, startTask, dismissTask, getDownloadUrl],
+  )
+
+  return <BackgroundTaskContext.Provider value={value}>{children}</BackgroundTaskContext.Provider>
+}
+
+export function useBackgroundTasks(): BackgroundTaskContextValue {
+  const context = useContext(BackgroundTaskContext)
+  if (!context) {
+    throw new Error('useBackgroundTasks must be used within a BackgroundTaskProvider')
+  }
+  return context
+}

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -1,5 +1,7 @@
 import type { PropsWithChildren } from 'react'
 
+import { BackgroundTaskTray } from '../../components/layout/BackgroundTaskTray'
+
 interface AppShellProps {
   isAuthenticated: boolean
   currentPath: string
@@ -30,6 +32,7 @@ export function AppShell({
     <div className="app-shell">
       <header className="app-shell__header">
         <div className="app-shell__brand">TTA AI 프로젝트 허브</div>
+        <BackgroundTaskTray />
         {isAuthenticated && (
           <nav aria-label="계정 메뉴" className="app-shell__nav">
             <button type="button" className="app-shell__drive" onClick={onOpenDrive}>

--- a/frontend/src/components/DefectReportWorkflow.tsx
+++ b/frontend/src/components/DefectReportWorkflow.tsx
@@ -11,11 +11,7 @@ import {
   type DefectWorkItem,
   type FinalizedDefectRow,
 } from './defect-report-workflow/types'
-import {
-  useDefectFinalize,
-  useFormalizeDefects,
-  type DefectFinalizeRow,
-} from './defect-report-workflow/hooks'
+import { useDefectFinalize, useFormalizeDefects } from './defect-report-workflow/hooks'
 import {
   buildAttachmentFileName,
   buildRowsFromJsonTable,

--- a/frontend/src/components/SecurityReportWorkflow.tsx
+++ b/frontend/src/components/SecurityReportWorkflow.tsx
@@ -69,6 +69,10 @@ export function SecurityReportWorkflow({
     setPreviewStatus('loading')
     setPreviewError(null)
     const taskHandle = startTask('security-report', '보안성 리포트 미리보기')
+    taskHandle.onCancel(() => {
+      setPreviewStatus('idle')
+      setPreviewError(null)
+    })
 
     try {
       const response = await fetch(
@@ -76,11 +80,19 @@ export function SecurityReportWorkflow({
         {
           method: 'POST',
           body: formData,
+          signal: taskHandle.signal,
         },
       )
 
+      if (taskHandle.signal.aborted) {
+        return
+      }
+
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
+        if (taskHandle.signal.aborted) {
+          return
+        }
         const detail =
           payload && typeof payload.detail === 'string'
             ? payload.detail
@@ -96,6 +108,10 @@ export function SecurityReportWorkflow({
         rows?: unknown
       }
 
+      if (taskHandle.signal.aborted) {
+        return
+      }
+
       const rawRows = Array.isArray(payload.rows) ? payload.rows : []
       const normalizedRows = rawRows
         .map((entry, index) => normalizeSecurityPreviewRow(entry, index))
@@ -109,13 +125,22 @@ export function SecurityReportWorkflow({
         return
       }
 
+      if (taskHandle.signal.aborted) {
+        return
+      }
+
       setRows(normalizedRows)
       setPreviewStatus('success')
       setPreviewError(null)
       setSaveStatus('idle')
       setSaveError(null)
-      taskHandle.complete({ type: 'data', payload: normalizedRows }, '미리보기 준비 완료')
+      if (!taskHandle.signal.aborted) {
+        taskHandle.complete({ type: 'data', payload: normalizedRows }, '미리보기 준비 완료')
+      }
     } catch (error) {
+      if (taskHandle.signal.aborted) {
+        return
+      }
       console.error('Failed to preview security report', error)
       setPreviewStatus('error')
       setPreviewError('보안성 리포트 초안을 생성하는 중 예기치 않은 오류가 발생했습니다.')
@@ -152,6 +177,10 @@ export function SecurityReportWorkflow({
     setSaveStatus('loading')
     setSaveError(null)
     const taskHandle = startTask('security-report', '보안성 리포트 저장')
+    taskHandle.onCancel(() => {
+      setSaveStatus('idle')
+      setSaveError(null)
+    })
 
     try {
       const response = await fetch(
@@ -159,11 +188,19 @@ export function SecurityReportWorkflow({
         {
           method: 'POST',
           body: formData,
+          signal: taskHandle.signal,
         },
       )
 
+      if (taskHandle.signal.aborted) {
+        return
+      }
+
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
+        if (taskHandle.signal.aborted) {
+          return
+        }
         const detail =
           payload && typeof payload.detail === 'string'
             ? payload.detail
@@ -180,10 +217,16 @@ export function SecurityReportWorkflow({
         modifiedTime?: unknown
       }
 
-      setSaveStatus('success')
-      taskHandle.complete({ type: 'data', payload }, '보안성 리포트 저장 완료')
+      if (taskHandle.signal.aborted) {
+        return
+      }
 
-      if (typeof window !== 'undefined') {
+      setSaveStatus('success')
+      if (!taskHandle.signal.aborted) {
+        taskHandle.complete({ type: 'data', payload }, '보안성 리포트 저장 완료')
+      }
+
+      if (typeof window !== 'undefined' && !taskHandle.signal.aborted) {
         const nextParams = new URLSearchParams(window.location.search)
         if (projectName && projectName !== projectId && !nextParams.get('name')) {
           nextParams.set('name', projectName)
@@ -217,6 +260,9 @@ export function SecurityReportWorkflow({
         )
       }
     } catch (error) {
+      if (taskHandle.signal.aborted) {
+        return
+      }
       console.error('Failed to save security report', error)
       setSaveStatus('error')
       setSaveError('보안성 리포트를 저장하는 중 예기치 않은 오류가 발생했습니다.')

--- a/frontend/src/components/SecurityReportWorkflow.tsx
+++ b/frontend/src/components/SecurityReportWorkflow.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { FileUploader } from './FileUploader'
 import type { FileType } from './fileUploaderTypes'
 import { navigate } from '../navigation'
+import { useBackgroundTasks } from '../app/background/BackgroundTaskContext'
 import {
   SECURITY_COLUMNS,
   type SecurityColumn,
@@ -27,6 +28,7 @@ export function SecurityReportWorkflow({
   projectId,
   projectName,
 }: SecurityReportWorkflowProps) {
+  const { startTask } = useBackgroundTasks()
   const [sourceFiles, setSourceFiles] = useState<File[]>([])
   const [previewStatus, setPreviewStatus] = useState<AsyncStatus>('idle')
   const [previewError, setPreviewError] = useState<string | null>(null)
@@ -66,6 +68,7 @@ export function SecurityReportWorkflow({
 
     setPreviewStatus('loading')
     setPreviewError(null)
+    const taskHandle = startTask('security-report', '보안성 리포트 미리보기')
 
     try {
       const response = await fetch(
@@ -84,6 +87,7 @@ export function SecurityReportWorkflow({
             : '보안성 리포트 초안을 생성하는 중 오류가 발생했습니다.'
         setPreviewStatus('error')
         setPreviewError(detail)
+        taskHandle.fail(detail)
         return
       }
 
@@ -101,6 +105,7 @@ export function SecurityReportWorkflow({
         setPreviewStatus('error')
         setPreviewError('생성된 보안성 결함 데이터를 찾지 못했습니다.')
         setRows([])
+        taskHandle.fail('생성된 보안성 결함 데이터를 찾지 못했습니다.')
         return
       }
 
@@ -109,12 +114,14 @@ export function SecurityReportWorkflow({
       setPreviewError(null)
       setSaveStatus('idle')
       setSaveError(null)
+      taskHandle.complete({ type: 'data', payload: normalizedRows }, '미리보기 준비 완료')
     } catch (error) {
       console.error('Failed to preview security report', error)
       setPreviewStatus('error')
       setPreviewError('보안성 리포트 초안을 생성하는 중 예기치 않은 오류가 발생했습니다.')
+      taskHandle.fail('미리보기 중 오류가 발생했습니다.')
     }
-  }, [backendUrl, projectId, sourceFiles])
+  }, [backendUrl, projectId, sourceFiles, startTask])
 
   const handleCellChange = useCallback((rowId: string, key: SecurityRowKey, value: string) => {
     setRows((prev) =>
@@ -144,6 +151,7 @@ export function SecurityReportWorkflow({
 
     setSaveStatus('loading')
     setSaveError(null)
+    const taskHandle = startTask('security-report', '보안성 리포트 저장')
 
     try {
       const response = await fetch(
@@ -162,6 +170,7 @@ export function SecurityReportWorkflow({
             : '보안성 리포트를 저장하는 중 오류가 발생했습니다.'
         setSaveStatus('error')
         setSaveError(detail)
+        taskHandle.fail(detail)
         return
       }
 
@@ -172,6 +181,7 @@ export function SecurityReportWorkflow({
       }
 
       setSaveStatus('success')
+      taskHandle.complete({ type: 'data', payload }, '보안성 리포트 저장 완료')
 
       if (typeof window !== 'undefined') {
         const nextParams = new URLSearchParams(window.location.search)
@@ -210,8 +220,9 @@ export function SecurityReportWorkflow({
       console.error('Failed to save security report', error)
       setSaveStatus('error')
       setSaveError('보안성 리포트를 저장하는 중 예기치 않은 오류가 발생했습니다.')
+      taskHandle.fail('저장 중 오류가 발생했습니다.')
     }
-  }, [backendUrl, projectId, projectName, rows])
+  }, [backendUrl, projectId, projectName, rows, startTask])
 
   const openFullscreen = useCallback(() => {
     setIsFullscreenPreview(true)

--- a/frontend/src/components/defect-report-workflow/hooks.ts
+++ b/frontend/src/components/defect-report-workflow/hooks.ts
@@ -745,6 +745,10 @@ export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
       setStatus('loading')
       setError(null)
       const taskHandle = startTask('defect-report', '결함 리포트 저장')
+      taskHandle.onCancel(() => {
+        setStatus('idle')
+        setError(null)
+      })
 
       const formData = new FormData()
       formData.append('menu_id', 'defect-report')
@@ -785,11 +789,19 @@ export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
           {
             method: 'POST',
             body: formData,
+            signal: taskHandle.signal,
           },
         )
 
+        if (taskHandle.signal.aborted) {
+          return null
+        }
+
         if (!response.ok) {
           const payload = await response.json().catch(() => null)
+          if (taskHandle.signal.aborted) {
+            return null
+          }
           const detail =
             payload && typeof payload.detail === 'string'
               ? payload.detail
@@ -801,10 +813,18 @@ export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
         }
 
         const payload = (await response.json().catch(() => ({}))) as DefectFinalizeResponse
+        if (taskHandle.signal.aborted) {
+          return null
+        }
         setStatus('success')
-        taskHandle.complete({ type: 'data', payload }, '결함 리포트 저장 완료')
+        if (!taskHandle.signal.aborted) {
+          taskHandle.complete({ type: 'data', payload }, '결함 리포트 저장 완료')
+        }
         return payload
       } catch (caught) {
+        if (taskHandle.signal.aborted) {
+          return null
+        }
         console.error('Failed to finalize defect report', caught)
         setStatus('error')
         setError('결함 리포트를 생성하는 중 예기치 않은 오류가 발생했습니다.')

--- a/frontend/src/components/defect-report-workflow/hooks.ts
+++ b/frontend/src/components/defect-report-workflow/hooks.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useBackgroundTasks } from '../../app/background/BackgroundTaskContext'
 
 import {
   ATTACHMENT_ACCEPT,
@@ -731,6 +732,7 @@ interface DefectFinalizeResponse {
 export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
   const [status, setStatus] = useState<AsyncStatus>('idle')
   const [error, setError] = useState<string | null>(null)
+  const { startTask } = useBackgroundTasks()
 
   const finalize = useCallback(
     async (rows: FinalizedDefectRow[], attachments: AttachmentMap) => {
@@ -742,6 +744,7 @@ export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
 
       setStatus('loading')
       setError(null)
+      const taskHandle = startTask('defect-report', '결함 리포트 저장')
 
       const formData = new FormData()
       formData.append('menu_id', 'defect-report')
@@ -793,20 +796,23 @@ export function useDefectFinalize({ backendUrl, projectId }: FinalizeOptions) {
               : '결함 리포트를 생성하는 중 오류가 발생했습니다.'
           setStatus('error')
           setError(detail)
+          taskHandle.fail(detail)
           return null
         }
 
         const payload = (await response.json().catch(() => ({}))) as DefectFinalizeResponse
         setStatus('success')
+        taskHandle.complete({ type: 'data', payload }, '결함 리포트 저장 완료')
         return payload
       } catch (caught) {
         console.error('Failed to finalize defect report', caught)
         setStatus('error')
         setError('결함 리포트를 생성하는 중 예기치 않은 오류가 발생했습니다.')
+        taskHandle.fail('결함 리포트를 저장하는 중 오류가 발생했습니다.')
         return null
       }
     },
-    [backendUrl, projectId],
+    [backendUrl, projectId, startTask],
   )
 
   const reset = useCallback(() => {

--- a/frontend/src/components/layout/BackgroundTaskTray.tsx
+++ b/frontend/src/components/layout/BackgroundTaskTray.tsx
@@ -42,15 +42,20 @@ export function BackgroundTaskTray() {
         작업 현황
         <span className="app-shell__tasks-count">{runningCount}</span>
       </button>
+
       {isOpen && (
         <div className="app-shell__tasks-panel" role="dialog" aria-label="백그라운드 작업 현황">
           <ul className="app-shell__tasks-list">
             {sortedTasks.length === 0 ? (
-              <li className="app-shell__task app-shell__task--empty">현재 진행 중인 작업이 없습니다.</li>
+              <li className="app-shell__task app-shell__task--empty">
+                현재 진행 중인 작업이 없습니다.
+              </li>
             ) : null}
+
             {sortedTasks.map((task) => {
               const statusLabel = formatStatus(task.status)
-              const downloadResult = task.result && task.result.type === 'download' ? task.result : null
+              const downloadResult =
+                task.result && task.result.type === 'download' ? task.result : null
               const warningsCount = downloadResult?.warnings?.length ?? 0
               const hasWarnings = warningsCount > 0
 
@@ -72,53 +77,79 @@ export function BackgroundTaskTray() {
               }
 
               const primaryLabel = (() => {
-                if (downloadResult) {
-                  return '다운로드'
-                }
-                if (task.result?.type === 'navigate') {
+                if (downloadResult) return '다운로드'
+                if (task.result?.type === 'navigate')
                   return task.result.label ?? '열기'
-                }
                 return null
               })()
 
               return (
-                <li key={task.id} className={`app-shell__task app-shell__task--${task.status}`}>
+                <li
+                  key={task.id}
+                  className={`app-shell__task app-shell__task--${task.status}`}
+                >
                   <div className="app-shell__task-main">
                     <div className="app-shell__task-title">{task.label}</div>
                     <div className="app-shell__task-status">
-                      <span className={`app-shell__task-status-badge app-shell__task-status-badge--${task.status}`}>
+                      <span
+                        className={`app-shell__task-status-badge app-shell__task-status-badge--${task.status}`}
+                      >
                         {statusLabel}
                       </span>
-                      {task.message ? <span className="app-shell__task-message">{task.message}</span> : null}
+                      {task.message ? (
+                        <span className="app-shell__task-message">
+                          {task.message}
+                        </span>
+                      ) : null}
                       {task.status === 'failed' && task.errorMessage ? (
-                        <span className="app-shell__task-error">{task.errorMessage}</span>
+                        <span className="app-shell__task-error">
+                          {task.errorMessage}
+                        </span>
                       ) : null}
                       {hasWarnings ? (
-                        <span className="app-shell__task-warning">주의 사항 {warningsCount}건</span>
+                        <span className="app-shell__task-warning">
+                          주의 사항 {warningsCount}건
+                        </span>
                       ) : null}
                     </div>
                   </div>
+
                   <div className="app-shell__task-actions">
                     {primaryLabel && task.status === 'succeeded' ? (
-                      <button type="button" className="app-shell__task-button" onClick={handlePrimaryAction}>
+                      <button
+                        type="button"
+                        className="app-shell__task-button"
+                        onClick={handlePrimaryAction}
+                      >
                         {primaryLabel}
                       </button>
                     ) : null}
-                    <button
-                      type="button"
-                      className="app-shell__task-button app-shell__task-button--dismiss"
-                      onClick={() => {
-                        if (window.confirm('정말로 이 작업을 중단하시겠습니까?')) {
-                          if (task.status === 'running') {
+
+                    {task.status === 'running' ? (
+                      <button
+                        type="button"
+                        className="app-shell__task-button app-shell__task-button--cancel"
+                        onClick={() => {
+                          if (window.confirm('정말로 이 작업을 중단하시겠습니까?')) {
                             cancelTask(task.id)
-                          } else {
-                            dismissTask(task.id)
                           }
-                        }
-                      }}
-                    >
-                      작업 중단
-                    </button>
+                        }}
+                        aria-label="작업 중단"
+                        title="작업 중단"
+                      >
+                        작업 중단
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        className="app-shell__task-button app-shell__task-button--dismiss"
+                        onClick={() => dismissTask(task.id)}
+                        aria-label="목록에서 제거"
+                        title="목록에서 제거"
+                      >
+                        <span aria-hidden="true">×</span>
+                      </button>
+                    )}
                   </div>
                 </li>
               )

--- a/frontend/src/components/layout/BackgroundTaskTray.tsx
+++ b/frontend/src/components/layout/BackgroundTaskTray.tsx
@@ -2,8 +2,9 @@ import { useMemo, useState } from 'react'
 
 import { navigate } from '../../navigation'
 import { useBackgroundTasks } from '../../app/background/BackgroundTaskContext'
+import type { BackgroundTaskStatus } from '../../app/background/BackgroundTaskContext'
 
-function formatStatus(status: 'running' | 'succeeded' | 'failed'): string {
+function formatStatus(status: BackgroundTaskStatus): string {
   switch (status) {
     case 'running':
       return '진행 중'
@@ -11,13 +12,15 @@ function formatStatus(status: 'running' | 'succeeded' | 'failed'): string {
       return '완료'
     case 'failed':
       return '실패'
+    case 'cancelled':
+      return '중단됨'
     default:
       return status
   }
 }
 
 export function BackgroundTaskTray() {
-  const { tasks, dismissTask, getDownloadUrl } = useBackgroundTasks()
+  const { tasks, cancelTask, dismissTask, getDownloadUrl } = useBackgroundTasks()
   const [isOpen, setIsOpen] = useState(false)
 
   const sortedTasks = useMemo(
@@ -106,7 +109,11 @@ export function BackgroundTaskTray() {
                       className="app-shell__task-button app-shell__task-button--dismiss"
                       onClick={() => {
                         if (window.confirm('정말로 이 작업을 중단하시겠습니까?')) {
-                          dismissTask(task.id)
+                          if (task.status === 'running') {
+                            cancelTask(task.id)
+                          } else {
+                            dismissTask(task.id)
+                          }
                         }
                       }}
                     >

--- a/frontend/src/components/layout/BackgroundTaskTray.tsx
+++ b/frontend/src/components/layout/BackgroundTaskTray.tsx
@@ -1,0 +1,124 @@
+import { useMemo, useState } from 'react'
+
+import { navigate } from '../../navigation'
+import { useBackgroundTasks } from '../../app/background/BackgroundTaskContext'
+
+function formatStatus(status: 'running' | 'succeeded' | 'failed'): string {
+  switch (status) {
+    case 'running':
+      return '진행 중'
+    case 'succeeded':
+      return '완료'
+    case 'failed':
+      return '실패'
+    default:
+      return status
+  }
+}
+
+export function BackgroundTaskTray() {
+  const { tasks, dismissTask, getDownloadUrl } = useBackgroundTasks()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const sortedTasks = useMemo(
+    () => [...tasks].sort((a, b) => b.createdAt - a.createdAt),
+    [tasks],
+  )
+
+  const runningCount = sortedTasks.filter((task) => task.status === 'running').length
+
+  return (
+    <div className="app-shell__tasks">
+      <button
+        type="button"
+        className={`app-shell__tasks-toggle${isOpen ? ' app-shell__tasks-toggle--open' : ''}`}
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+      >
+        작업 현황
+        <span className="app-shell__tasks-count">{runningCount}</span>
+      </button>
+      {isOpen && (
+        <div className="app-shell__tasks-panel" role="dialog" aria-label="백그라운드 작업 현황">
+          <ul className="app-shell__tasks-list">
+            {sortedTasks.length === 0 ? (
+              <li className="app-shell__task app-shell__task--empty">현재 진행 중인 작업이 없습니다.</li>
+            ) : null}
+            {sortedTasks.map((task) => {
+              const statusLabel = formatStatus(task.status)
+              const downloadResult = task.result && task.result.type === 'download' ? task.result : null
+              const warningsCount = downloadResult?.warnings?.length ?? 0
+              const hasWarnings = warningsCount > 0
+
+              const handlePrimaryAction = () => {
+                if (downloadResult) {
+                  const url = getDownloadUrl(task.id)
+                  if (!url) {
+                    return
+                  }
+                  const link = document.createElement('a')
+                  link.href = url
+                  link.download = downloadResult.filename
+                  document.body.appendChild(link)
+                  link.click()
+                  document.body.removeChild(link)
+                } else if (task.result?.type === 'navigate') {
+                  navigate(task.result.url)
+                }
+              }
+
+              const primaryLabel = (() => {
+                if (downloadResult) {
+                  return '다운로드'
+                }
+                if (task.result?.type === 'navigate') {
+                  return task.result.label ?? '열기'
+                }
+                return null
+              })()
+
+              return (
+                <li key={task.id} className={`app-shell__task app-shell__task--${task.status}`}>
+                  <div className="app-shell__task-main">
+                    <div className="app-shell__task-title">{task.label}</div>
+                    <div className="app-shell__task-status">
+                      <span className={`app-shell__task-status-badge app-shell__task-status-badge--${task.status}`}>
+                        {statusLabel}
+                      </span>
+                      {task.message ? <span className="app-shell__task-message">{task.message}</span> : null}
+                      {task.status === 'failed' && task.errorMessage ? (
+                        <span className="app-shell__task-error">{task.errorMessage}</span>
+                      ) : null}
+                      {hasWarnings ? (
+                        <span className="app-shell__task-warning">주의 사항 {warningsCount}건</span>
+                      ) : null}
+                    </div>
+                  </div>
+                  <div className="app-shell__task-actions">
+                    {primaryLabel && task.status === 'succeeded' ? (
+                      <button type="button" className="app-shell__task-button" onClick={handlePrimaryAction}>
+                        {primaryLabel}
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="app-shell__task-button app-shell__task-button--dismiss"
+                      onClick={() => {
+                        if (window.confirm('정말로 이 작업을 중단하시겠습니까?')) {
+                          dismissTask(task.id)
+                        }
+                      }}
+                    >
+                      작업 중단
+                    </button>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
@@ -558,6 +558,10 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
     setFinalStatus('loading')
     setFinalError(null)
     const taskHandle = startTask('testcase-generation', '테스트케이스 생성')
+    taskHandle.onCancel(() => {
+      setFinalStatus('idle')
+      setFinalError(null)
+    })
 
     const payload = {
       projectOverview,
@@ -583,16 +587,28 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(payload),
+          signal: taskHandle.signal,
         },
       )
 
+      if (taskHandle.signal.aborted) {
+        return
+      }
+
       if (!response.ok) {
         const body = await response.json().catch(() => null)
+        if (taskHandle.signal.aborted) {
+          return
+        }
         const detail = typeof body?.detail === 'string' ? body.detail : '테스트케이스를 완성하지 못했습니다.'
         throw new Error(detail)
       }
 
       const body = (await response.json()) as FinalizeResponsePayload
+
+      if (taskHandle.signal.aborted) {
+        return
+      }
 
       const rows = Array.isArray(body.rows) ? body.rows : []
       if (rows.length === 0) {
@@ -624,9 +640,14 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
       const targetUrl = `/projects/${encodeURIComponent(projectId)}/testcases/edit${
         query ? `?${query}` : ''
       }`
-      taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '테스트케이스 생성 완료')
-      navigate(targetUrl)
+      if (!taskHandle.signal.aborted) {
+        taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '테스트케이스 생성 완료')
+        navigate(targetUrl)
+      }
     } catch (error) {
+      if (taskHandle.signal.aborted) {
+        return
+      }
       const message = error instanceof Error ? error.message : '테스트케이스를 완성하지 못했습니다.'
       setFinalStatus('error')
       setFinalError(message)

--- a/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
+++ b/frontend/src/components/testcase-workflow/TestcaseWorkflow.tsx
@@ -3,6 +3,7 @@ import './TestcaseWorkflow.css'
 import { useCallback, useMemo, useRef, useState } from 'react'
 
 import { navigate } from '../../navigation'
+import { useBackgroundTasks } from '../../app/background/BackgroundTaskContext'
 import { FileUploader } from '../FileUploader'
 import type { FileType } from '../fileUploaderTypes'
 
@@ -48,7 +49,6 @@ interface TestcaseWorkflowProps {
 type Step = 'feature' | 'scenarios'
 
 const FEATURE_FILE_TYPES: FileType[] = ['xlsx', 'xls', 'csv']
-const ATTACHMENT_FILE_TYPES: FileType[] = ['jpg', 'png']
 const SCENARIO_COUNT_OPTIONS = [3, 4, 5] as const
 
 interface FinalizeResponseRow {
@@ -72,6 +72,7 @@ interface FinalizeResponsePayload {
 }
 
 export function TestcaseWorkflow({ projectId, backendUrl, projectName }: TestcaseWorkflowProps) {
+  const { startTask } = useBackgroundTasks()
   const [step, setStep] = useState<Step>('feature')
   const [projectOverview, setProjectOverview] = useState<string>('')
   const [featureStatus, setFeatureStatus] = useState<'idle' | 'loading' | 'error'>('idle')
@@ -556,6 +557,7 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
   const handleFinalize = useCallback(async () => {
     setFinalStatus('loading')
     setFinalError(null)
+    const taskHandle = startTask('testcase-generation', '테스트케이스 생성')
 
     const payload = {
       projectOverview,
@@ -619,15 +621,18 @@ export function TestcaseWorkflow({ projectId, backendUrl, projectName }: Testcas
       }
 
       const query = nextParams.toString()
-      navigate(
-        `/projects/${encodeURIComponent(projectId)}/testcases/edit${query ? `?${query}` : ''}`,
-      )
+      const targetUrl = `/projects/${encodeURIComponent(projectId)}/testcases/edit${
+        query ? `?${query}` : ''
+      }`
+      taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '테스트케이스 생성 완료')
+      navigate(targetUrl)
     } catch (error) {
       const message = error instanceof Error ? error.message : '테스트케이스를 완성하지 못했습니다.'
       setFinalStatus('error')
       setFinalError(message)
+      taskHandle.fail(message)
     }
-  }, [backendUrl, groups, projectId, projectOverview, projectName])
+  }, [backendUrl, groups, projectId, projectOverview, projectName, startTask])
 
   return (
     <div className="testcase-workflow">

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { BackgroundTaskProvider } from './app/background/BackgroundTaskContext.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BackgroundTaskProvider>
+      <App />
+    </BackgroundTaskProvider>
   </StrictMode>,
 )

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -6,6 +6,7 @@ import { DefectReportWorkflow } from '../components/DefectReportWorkflow'
 import { SecurityReportWorkflow } from '../components/SecurityReportWorkflow'
 import { TestcaseWorkflow } from '../components/testcase-workflow/TestcaseWorkflow'
 import { Modal } from '../components/Modal'
+import { useBackgroundTasks } from '../app/background/BackgroundTaskContext'
 import { getBackendUrl } from '../config'
 import { navigate } from '../navigation'
 
@@ -310,14 +311,13 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const backendUrl = useMemo(() => getBackendUrl(), [])
   const [activeItem, setActiveItem] = useState<MenuItemId>(FIRST_MENU_ITEM)
   const [itemStates, setItemStates] = useState<Record<MenuItemId, ItemState>>(() => createInitialItemStates())
-  const controllersRef = useRef<Record<MenuItemId, AbortController | null>>(
-    Object.fromEntries(MENU_ITEM_IDS.map((id) => [id, null])) as Record<MenuItemId, AbortController | null>,
-  )
   const downloadUrlsRef = useRef<Record<MenuItemId, string | null>>(
     Object.fromEntries(MENU_ITEM_IDS.map((id) => [id, null])) as Record<MenuItemId, string | null>,
   )
   const performanceOverridesRef = useRef<Record<string, string> | null>(null)
   const [performanceModalState, setPerformanceModalState] = useState<PerformanceOSModalState | null>(null)
+  const { startTask } = useBackgroundTasks()
+  const isMountedRef = useRef(true)
 
   const menuById = useMemo(() => {
     return MENU_ITEMS.reduce((acc, item) => {
@@ -343,6 +343,12 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const hasRequiredDocuments = (activeContent.requiredDocuments?.length ?? 0) > 0
   const handleSelectAnotherProject = useCallback(() => {
     navigate('/projects')
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false
+    }
   }, [])
 
   const handleChangeFiles = useCallback(
@@ -711,9 +717,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         releaseDownloadUrl(id, current.downloadUrl)
       }
 
-      controllersRef.current[id]?.abort()
-      const controller = new AbortController()
-      controllersRef.current[id] = controller
+      const taskHandle = startTask(id, menu.label)
 
       const formData = new FormData()
       formData.append('menu_id', id)
@@ -740,7 +744,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           {
             method: 'POST',
             body: formData,
-            signal: controller.signal,
           },
         )
 
@@ -792,7 +795,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               }
             }
 
-            if (!controller.signal.aborted) {
             setItemStates((prev) => ({
               ...prev,
               [id]: {
@@ -804,7 +806,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                 downloadName: null,
               },
             }))
-          }
 
             if (modalFiles.length > 0) {
               setPerformanceModalState({
@@ -813,19 +814,21 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                 selections: Object.fromEntries(modalFiles.map((file) => [file.index, ''])),
                 error: null,
               })
-            } else if (!controller.signal.aborted) {
-            setItemStates((prev) => ({
-              ...prev,
-              [id]: {
-                ...prev[id],
-                status: 'error',
-                errorMessage: '업로드된 파일의 OS 유형을 판별하지 못했습니다. 다시 시도해 주세요.',
-                warnings: [],
-                downloadUrl: null,
-                downloadName: null,
-              },
-            }))
-          }
+              taskHandle.fail('OS 종류 선택이 필요합니다.')
+            } else {
+              setItemStates((prev) => ({
+                ...prev,
+                [id]: {
+                  ...prev[id],
+                  status: 'error',
+                  errorMessage: '업로드된 파일의 OS 유형을 판별하지 못했습니다. 다시 시도해 주세요.',
+                  warnings: [],
+                  downloadUrl: null,
+                  downloadName: null,
+                },
+              }))
+              taskHandle.fail('OS 정보를 확인하지 못했습니다.')
+            }
             return
           }
 
@@ -842,19 +845,18 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             }
           }
 
-          if (!controller.signal.aborted) {
-            setItemStates((prev) => ({
-              ...prev,
-              [id]: {
-                ...prev[id],
-                status: 'error',
-                errorMessage: detail,
-                warnings: [],
-                downloadUrl: null,
-                downloadName: null,
-              },
-            }))
-          }
+          setItemStates((prev) => ({
+            ...prev,
+            [id]: {
+              ...prev[id],
+              status: 'error',
+              errorMessage: detail,
+              warnings: [],
+              downloadUrl: null,
+              downloadName: null,
+            },
+          }))
+          taskHandle.fail(detail)
           return
         }
 
@@ -864,10 +866,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             payload = (await response.json()) as ConfigurationCaptureResponse
           } catch {
             payload = null
-          }
-
-          if (controller.signal.aborted) {
-            return
           }
 
           const captureFiles: ConfigurationCaptureFile[] = Array.isArray(payload?.files)
@@ -887,6 +885,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                 errorMessage: '추출된 형상 이미지 정보를 확인하지 못했습니다.',
               },
             }))
+            taskHandle.fail('형상 이미지 정보를 확인하지 못했습니다.')
             return
           }
 
@@ -916,11 +915,13 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           }
 
           const query = nextParams.toString()
-          navigate(
-            `/projects/${encodeURIComponent(projectId)}/configuration-images/edit${
-              query ? `?${query}` : ''
-            }`,
-          )
+          const targetUrl = `/projects/${encodeURIComponent(projectId)}/configuration-images/edit${
+            query ? `?${query}` : ''
+          }`
+          taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '형상 이미지 추출 완료')
+          if (isMountedRef.current) {
+            navigate(targetUrl)
+          }
           return
         }
 
@@ -932,10 +933,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             payload = null
           }
 
-          if (controller.signal.aborted) {
-            return
-          }
-
           if (!payload || typeof payload.fileId !== 'string') {
             setItemStates((prev) => ({
               ...prev,
@@ -945,6 +942,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                 errorMessage: '생성된 기능리스트 정보를 확인하지 못했습니다.',
               },
             }))
+            taskHandle.fail('기능리스트 정보를 확인하지 못했습니다.')
             return
           }
 
@@ -970,16 +968,17 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           }
 
           const query = nextParams.toString()
-          navigate(
-            `/projects/${encodeURIComponent(projectId)}/feature-list/edit${query ? `?${query}` : ''}`,
-          )
+          const targetUrl = `/projects/${encodeURIComponent(projectId)}/feature-list/edit${
+            query ? `?${query}` : ''
+          }`
+          taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '기능리스트 생성 완료')
+          if (isMountedRef.current) {
+            navigate(targetUrl)
+          }
           return
         }
 
         const blob = await response.blob()
-        if (controller.signal.aborted) {
-          return
-        }
 
         const disposition = response.headers.get('content-disposition')
         const parsedName = parseFileNameFromDisposition(disposition)
@@ -1036,11 +1035,13 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           }
         })
         downloadUrlsRef.current[id] = objectUrl
-      } catch (error) {
-        if (controller.signal.aborted) {
-          return
-        }
 
+        const successMessage = warnings.length > 0 ? '생성 완료 (주의 사항 있음)' : '생성 완료'
+        taskHandle.complete(
+          { type: 'download', blob, filename: safeName, contentType, warnings },
+          successMessage,
+        )
+      } catch (error) {
         const fallback =
           error instanceof Error
             ? error.message
@@ -1057,13 +1058,18 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             downloadName: null,
           },
         }))
-      } finally {
-        if (controllersRef.current[id] === controller) {
-          controllersRef.current[id] = null
-        }
+        taskHandle.fail(fallback)
       }
     },
-    [backendUrl, itemStates, menuById, projectId, projectName, releaseDownloadUrl],
+    [
+      backendUrl,
+      itemStates,
+      menuById,
+      projectId,
+      projectName,
+      releaseDownloadUrl,
+      startTask,
+    ],
   )
 
   const handlePerformanceModalClose = useCallback(() => {
@@ -1111,8 +1117,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
 
   const handleReset = useCallback(
     (id: MenuItemId) => {
-      controllersRef.current[id]?.abort()
-      controllersRef.current[id] = null
       if (id === 'performance-report') {
         performanceOverridesRef.current = null
         setPerformanceModalState(null)
@@ -1136,10 +1140,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   useEffect(() => {
     return () => {
       MENU_ITEM_IDS.forEach((id) => {
-        const controller = controllersRef.current[id as MenuItemId]
-        controller?.abort()
-        controllersRef.current[id as MenuItemId] = null
-
         const downloadUrl = downloadUrlsRef.current[id as MenuItemId]
         if (downloadUrl) {
           URL.revokeObjectURL(downloadUrl)

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -718,6 +718,19 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
       }
 
       const taskHandle = startTask(id, menu.label)
+      taskHandle.onCancel(() => {
+        setItemStates((prev) => ({
+          ...prev,
+          [id]: {
+            ...prev[id],
+            status: 'idle',
+            errorMessage: null,
+            warnings: [],
+            downloadUrl: null,
+            downloadName: null,
+          },
+        }))
+      })
 
       const formData = new FormData()
       formData.append('menu_id', id)
@@ -744,8 +757,13 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           {
             method: 'POST',
             body: formData,
+            signal: taskHandle.signal,
           },
         )
+
+        if (taskHandle.signal.aborted) {
+          return
+        }
 
         if (!response.ok) {
           if (response.status === 409 && id === 'performance-report') {
@@ -795,6 +813,10 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               }
             }
 
+            if (taskHandle.signal.aborted) {
+              return
+            }
+
             setItemStates((prev) => ({
               ...prev,
               [id]: {
@@ -816,6 +838,10 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               })
               taskHandle.fail('OS 종류 선택이 필요합니다.')
             } else {
+              if (taskHandle.signal.aborted) {
+                return
+              }
+
               setItemStates((prev) => ({
                 ...prev,
                 [id]: {
@@ -845,6 +871,10 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             }
           }
 
+          if (taskHandle.signal.aborted) {
+            return
+          }
+
           setItemStates((prev) => ({
             ...prev,
             [id]: {
@@ -860,6 +890,10 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           return
         }
 
+        if (taskHandle.signal.aborted) {
+          return
+        }
+
         if (id === 'configuration-images') {
           let payload: ConfigurationCaptureResponse | null = null
           try {
@@ -868,15 +902,21 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             payload = null
           }
 
+          if (taskHandle.signal.aborted) {
+            return
+          }
+
           const captureFiles: ConfigurationCaptureFile[] = Array.isArray(payload?.files)
             ? (payload?.files as ConfigurationCaptureFile[])
             : []
           const files: Array<ConfigurationCaptureFile & { id: string }> = captureFiles.filter(
-            (file): file is ConfigurationCaptureFile & { id: string } =>
-              typeof file?.id === 'string',
+            (file): file is ConfigurationCaptureFile & { id: string } => typeof file?.id === 'string',
           )
 
           if (!payload || files.length === 0) {
+            if (taskHandle.signal.aborted) {
+              return
+            }
             setItemStates((prev) => ({
               ...prev,
               [id]: {
@@ -886,6 +926,10 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               },
             }))
             taskHandle.fail('형상 이미지 정보를 확인하지 못했습니다.')
+            return
+          }
+
+          if (taskHandle.signal.aborted) {
             return
           }
 
@@ -918,10 +962,17 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           const targetUrl = `/projects/${encodeURIComponent(projectId)}/configuration-images/edit${
             query ? `?${query}` : ''
           }`
-          taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '형상 이미지 추출 완료')
-          if (isMountedRef.current) {
-            navigate(targetUrl)
+
+          if (!taskHandle.signal.aborted) {
+            taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '형상 이미지 추출 완료')
+            if (isMountedRef.current) {
+              navigate(targetUrl)
+            }
           }
+          return
+        }
+
+        if (taskHandle.signal.aborted) {
           return
         }
 
@@ -933,7 +984,14 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             payload = null
           }
 
+          if (taskHandle.signal.aborted) {
+            return
+          }
+
           if (!payload || typeof payload.fileId !== 'string') {
+            if (taskHandle.signal.aborted) {
+              return
+            }
             setItemStates((prev) => ({
               ...prev,
               [id]: {
@@ -943,6 +1001,10 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               },
             }))
             taskHandle.fail('기능리스트 정보를 확인하지 못했습니다.')
+            return
+          }
+
+          if (taskHandle.signal.aborted) {
             return
           }
 
@@ -971,14 +1033,25 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
           const targetUrl = `/projects/${encodeURIComponent(projectId)}/feature-list/edit${
             query ? `?${query}` : ''
           }`
-          taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '기능리스트 생성 완료')
-          if (isMountedRef.current) {
-            navigate(targetUrl)
+
+          if (!taskHandle.signal.aborted) {
+            taskHandle.complete({ type: 'navigate', url: targetUrl, label: '열기' }, '기능리스트 생성 완료')
+            if (isMountedRef.current) {
+              navigate(targetUrl)
+            }
           }
           return
         }
 
+        if (taskHandle.signal.aborted) {
+          return
+        }
+
         const blob = await response.blob()
+
+        if (taskHandle.signal.aborted) {
+          return
+        }
 
         const disposition = response.headers.get('content-disposition')
         const parsedName = parseFileNameFromDisposition(disposition)
@@ -1016,6 +1089,9 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         }
 
         setItemStates((prev) => {
+          if (taskHandle.signal.aborted) {
+            return prev
+          }
           const previous = prev[id]
           if (previous?.downloadUrl) {
             releaseDownloadUrl(id, previous.downloadUrl)
@@ -1034,14 +1110,25 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
             },
           }
         })
+
+        if (taskHandle.signal.aborted) {
+          URL.revokeObjectURL(objectUrl)
+          return
+        }
+
         downloadUrlsRef.current[id] = objectUrl
 
         const successMessage = warnings.length > 0 ? '생성 완료 (주의 사항 있음)' : '생성 완료'
-        taskHandle.complete(
-          { type: 'download', blob, filename: safeName, contentType, warnings },
-          successMessage,
-        )
+        if (!taskHandle.signal.aborted) {
+          taskHandle.complete(
+            { type: 'download', blob, filename: safeName, contentType, warnings },
+            successMessage,
+          )
+        }
       } catch (error) {
+        if (taskHandle.signal.aborted) {
+          return
+        }
         const fallback =
           error instanceof Error
             ? error.message


### PR DESCRIPTION
## Summary
- keep the background task tray visible with a zero badge even when no jobs are running
- add an empty-state message and confirmation dialog before removing tasks, renaming the dismiss control to "작업 중단"

## Testing
- `npm run build` *(fails: missing testing dependencies such as vitest and @testing-library/react)*

------
https://chatgpt.com/codex/tasks/task_e_69084a4a413c83308888f9ead72acd42