### PR TITLE
feat: redesign project management layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,6 +12,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1.5rem;
   padding: 1.25rem clamp(1.5rem, 4vw, 3.5rem);
   background: rgba(15, 23, 42, 0.92);
   color: white;
@@ -19,12 +20,53 @@
   backdrop-filter: blur(12px);
 }
 
+.app-shell__header-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-shell__leading-action {
+  display: inline-flex;
+  align-items: center;
+}
+
+.app-shell__brand-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.75rem;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-shell__brand-button:hover,
+.app-shell__brand-button:focus-visible {
+  background: rgba(148, 163, 184, 0.22);
+  color: #f8fafc;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.24);
+}
+
+.app-shell__brand-button:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.85);
+  outline-offset: 3px;
+}
+
 .app-shell__tasks {
-  margin-left: auto;
-  margin-right: 1.5rem;
   position: relative;
   display: flex;
   align-items: center;
+}
+
+.app-shell__header-right {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 1.5rem;
 }
 
 .app-shell__tasks-toggle {
@@ -1473,29 +1515,26 @@
 }
 
 .project-management-sidebar-toggle {
-  position: absolute;
-  top: calc(var(--app-shell-main-padding-y) / 2);
-  left: calc(var(--app-shell-main-padding-x) / 2);
-  z-index: 3;
   width: 44px;
   height: 44px;
-  border: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 14px;
-  background: rgba(15, 23, 42, 0.92);
+  background: rgba(15, 23, 42, 0.65);
   color: #e2e8f0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
-  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .project-management-sidebar-toggle:hover,
 .project-management-sidebar-toggle:focus-visible {
   background: rgba(30, 41, 59, 0.95);
-  transform: translateY(-1px);
-  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.25);
+  color: #f8fafc;
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.28);
+  border-color: rgba(226, 232, 240, 0.55);
 }
 
 .project-management-sidebar-toggle:focus-visible {
@@ -2079,11 +2118,6 @@
 @media (max-width: 1024px) {
   .project-management-page {
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  .project-management-sidebar-toggle {
-    top: 1rem;
-    left: 1rem;
   }
 
   .project-management-sidebar {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -322,11 +322,13 @@
 }
 
 .app-shell__main {
+  --app-shell-main-padding-x: clamp(1.5rem, 4vw, 3.5rem);
+  --app-shell-main-padding-y: clamp(2rem, 4vw, 4rem);
   flex: 1;
   display: flex;
   align-items: stretch;
   justify-content: center;
-  padding: clamp(2rem, 4vw, 4rem) clamp(1.5rem, 4vw, 3.5rem);
+  padding: var(--app-shell-main-padding-y) var(--app-shell-main-padding-x);
 }
 
 .app-shell__footer {
@@ -1448,27 +1450,130 @@
 }
 
 .project-management-page {
-  width: min(1320px, 100%);
-  min-height: 70vh;
-  display: flex;
-  background: #ffffff;
-  border-radius: 24px;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  --project-management-sidebar-width: 280px;
+  position: relative;
+  display: grid;
+  grid-template-columns: var(--project-management-sidebar-width) minmax(0, 1fr);
+  align-self: stretch;
+  min-width: 0;
+  width: calc(100% + (2 * var(--app-shell-main-padding-x)));
+  margin: calc(-1 * var(--app-shell-main-padding-y)) calc(-1 * var(--app-shell-main-padding-x));
+  background: #f8fafc;
+  min-height: calc(100vh - (2 * var(--app-shell-main-padding-y)));
   overflow: hidden;
+  transition: grid-template-columns 0.3s ease;
 }
 
 .project-management-page--preview {
-  width: min(1560px, 100%);
+  --project-management-sidebar-width: 320px;
+}
+
+.project-management-page--sidebar-collapsed {
+  grid-template-columns: 0 minmax(0, 1fr);
+}
+
+.project-management-sidebar-toggle {
+  position: absolute;
+  top: calc(var(--app-shell-main-padding-y) / 2);
+  left: calc(var(--app-shell-main-padding-x) / 2);
+  z-index: 3;
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #e2e8f0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-management-sidebar-toggle:hover,
+.project-management-sidebar-toggle:focus-visible {
+  background: rgba(30, 41, 59, 0.95);
+  transform: translateY(-1px);
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.25);
+}
+
+.project-management-sidebar-toggle:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
+}
+
+.project-management-sidebar-toggle__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.project-management-sidebar-toggle__icon svg {
+  width: 22px;
+  height: 22px;
+  stroke-width: 2;
+}
+
+.project-management-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.project-management-sidebar-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 1;
+  border: none;
+}
+
+.project-management-page--sidebar-open .project-management-sidebar-backdrop {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (min-width: 1025px) {
+  .project-management-sidebar-backdrop {
+    display: none;
+  }
 }
 
 .project-management-sidebar {
-  flex: 0 0 260px;
+  position: relative;
+  z-index: 2;
+  width: var(--project-management-sidebar-width);
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
-  padding: 2rem 1.75rem;
+  padding: 2.5rem 2rem;
   background: #0f172a;
   color: #e2e8f0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  box-shadow: 1px 0 0 rgba(15, 23, 42, 0.4);
+  min-height: 100%;
+}
+
+.project-management-page--sidebar-collapsed .project-management-sidebar {
+  transform: translateX(-100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.project-management-page--sidebar-open .project-management-sidebar {
+  transform: translateX(0);
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .project-management-overview {
@@ -1565,8 +1670,9 @@
   display: flex;
   align-items: stretch;
   background: #f8fafc;
-  padding: 2.5rem;
+  padding: clamp(2rem, 3vw, 3rem);
   min-width: 0;
+  min-height: 0;
 }
 
 .project-management-content--preview {
@@ -1960,39 +2066,62 @@
   box-shadow: 0 10px 20px rgba(148, 163, 184, 0.24);
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1280px) {
   .project-management-page {
-    flex-direction: column;
+    --project-management-sidebar-width: 260px;
   }
 
   .project-management-sidebar {
-    flex: none;
-    width: 100%;
-    padding: 1.75rem 1.5rem;
-    border-right: none;
-    border-bottom: 1px solid rgba(226, 232, 240, 0.2);
+    padding: 2.25rem 1.75rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .project-management-page {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .project-management-sidebar-toggle {
+    top: 1rem;
+    left: 1rem;
+  }
+
+  .project-management-sidebar {
+    position: fixed;
+    top: calc(64px + 1rem);
+    left: 0;
+    bottom: 0;
+    width: min(var(--project-management-sidebar-width), 80vw);
+    max-width: 320px;
+    padding: 2rem 1.5rem 2.25rem;
+    transform: translateX(-100%);
+    opacity: 0;
+    pointer-events: none;
+    box-shadow: 18px 0 36px rgba(15, 23, 42, 0.25);
+  }
+
+  .project-management-page--sidebar-open .project-management-sidebar {
+    transform: translateX(0);
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .project-management-content {
-    padding: 1.75rem;
+    padding: clamp(1.5rem, 5vw, 2.25rem);
   }
 }
 
 @media (max-width: 720px) {
-  .project-management-page {
-    border-radius: 20px;
-  }
-
   .project-management-sidebar {
-    padding: 1.5rem 1.25rem;
+    padding: 1.75rem 1.35rem 2rem;
   }
 
   .project-management-menu__button {
-    padding: 0.75rem 0.85rem;
+    padding: 0.75rem 0.9rem;
   }
 
   .project-management-content {
-    padding: 1.5rem 1.25rem;
+    padding: clamp(1.25rem, 6vw, 1.75rem);
   }
 
   .project-management-content__inner {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -32,28 +32,98 @@
 }
 
 .app-shell__brand-button {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  padding: 0.35rem 0.75rem;
-  border: none;
+  gap: 0.9rem;
+  padding: 0.55rem 1.25rem 0.55rem 0.55rem;
   border-radius: 999px;
-  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.16) 0%, rgba(15, 23, 42, 0.28) 100%);
   color: inherit;
   font: inherit;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  text-align: left;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
 .app-shell__brand-button:hover,
 .app-shell__brand-button:focus-visible {
-  background: rgba(148, 163, 184, 0.22);
+  transform: translateY(-1px);
+  border-color: rgba(148, 197, 255, 0.65);
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35) 0%, rgba(30, 64, 175, 0.65) 100%);
   color: #f8fafc;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.24);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
 }
 
 .app-shell__brand-button:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.85);
+  outline: 2px solid rgba(226, 232, 240, 0.75);
   outline-offset: 3px;
+}
+
+.app-shell__brand-mark {
+  position: relative;
+  width: 2.45rem;
+  height: 2.45rem;
+  border-radius: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.95) 0%, rgba(59, 130, 246, 0.85) 100%);
+  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.35);
+}
+
+.app-shell__brand-mark-glow {
+  position: absolute;
+  inset: -30%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(224, 231, 255, 0.6), transparent 60%);
+  opacity: 0.8;
+}
+
+.app-shell__brand-initials {
+  position: relative;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f8fafc;
+  text-shadow: 0 4px 12px rgba(15, 23, 42, 0.4);
+}
+
+.app-shell__brand-wordmark {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  line-height: 1;
+}
+
+.app-shell__brand-text {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+  font-size: 1.32rem;
+  font-weight: 700;
+  letter-spacing: 0.015em;
+  color: #f1f5f9;
+  text-shadow: 0 8px 24px rgba(15, 23, 42, 0.4);
+}
+
+.app-shell__brand-primary {
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.app-shell__brand-highlight {
+  color: #bfdbfe;
+}
+
+.app-shell__brand-tagline {
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
 }
 
 .app-shell__tasks {
@@ -248,12 +318,6 @@
   background: rgba(248, 113, 113, 0.22);
   border-color: rgba(248, 113, 113, 0.6);
   color: #fee2e2;
-}
-
-.app-shell__brand {
-  font-size: 1.25rem;
-  font-weight: 700;
-  letter-spacing: 0.02em;
 }
 
 .app-shell__nav {
@@ -1506,32 +1570,30 @@
   transition: grid-template-columns 0.3s ease;
 }
 
-.project-management-page--preview {
-  --project-management-sidebar-width: 320px;
-}
-
 .project-management-page--sidebar-collapsed {
   grid-template-columns: 0 minmax(0, 1fr);
 }
 
 .project-management-sidebar-toggle {
-  width: 44px;
-  height: 44px;
+  width: 42px;
+  height: 42px;
   border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.65);
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.6);
   color: #e2e8f0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
   box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
-  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .project-management-sidebar-toggle:hover,
 .project-management-sidebar-toggle:focus-visible {
-  background: rgba(30, 41, 59, 0.95);
+  transform: translateY(-1px);
+  background: rgba(30, 41, 59, 0.9);
   color: #f8fafc;
   box-shadow: 0 20px 36px rgba(15, 23, 42, 0.28);
   border-color: rgba(226, 232, 240, 0.55);
@@ -1549,9 +1611,9 @@
 }
 
 .project-management-sidebar-toggle__icon svg {
-  width: 22px;
-  height: 22px;
-  stroke-width: 2;
+  width: 24px;
+  height: 24px;
+  stroke-width: 1.8;
 }
 
 .project-management-sr-only {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,6 +31,10 @@ function App() {
     navigate('/admin/prompts')
   }, [])
 
+  const handleClickBrand = useCallback(() => {
+    navigate('/projects')
+  }, [])
+
   return (
     <AppShell
       isAuthenticated={authStatus === 'authenticated'}
@@ -38,6 +42,7 @@ function App() {
       onLogout={handleLogout}
       onOpenDrive={handleOpenDrive}
       onNavigateAdmin={handleOpenAdmin}
+      onBrandClick={handleClickBrand}
     >
       {pageContent}
     </AppShell>

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -52,8 +52,23 @@ export function AppShell({
             {leadingAction ? (
               <div className="app-shell__leading-action">{leadingAction}</div>
             ) : null}
-            <button type="button" className="app-shell__brand-button" onClick={onBrandClick}>
-              <span className="app-shell__brand">TestMate</span>
+            <button
+              type="button"
+              className="app-shell__brand-button"
+              onClick={onBrandClick}
+              aria-label="프로젝트 선택 화면으로 이동"
+            >
+              <span className="app-shell__brand-mark" aria-hidden="true">
+                <span className="app-shell__brand-mark-glow" />
+                <span className="app-shell__brand-initials">TM</span>
+              </span>
+              <span className="app-shell__brand-wordmark">
+                <span className="app-shell__brand-text">
+                  <span className="app-shell__brand-primary">Test</span>
+                  <span className="app-shell__brand-highlight">Mate</span>
+                </span>
+                <span className="app-shell__brand-tagline">QA Workspace</span>
+              </span>
             </button>
           </div>
           <div className="app-shell__header-right">

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -1,6 +1,7 @@
-import type { PropsWithChildren } from 'react'
+import { useCallback, useMemo, useState, type PropsWithChildren, type ReactNode } from 'react'
 
 import { BackgroundTaskTray } from '../../components/layout/BackgroundTaskTray'
+import { AppShellHeaderContext } from './AppShellHeaderContext'
 
 interface AppShellProps {
   isAuthenticated: boolean
@@ -8,6 +9,7 @@ interface AppShellProps {
   onLogout: () => void
   onOpenDrive: () => void
   onNavigateAdmin: () => void
+  onBrandClick: () => void
 }
 
 export function AppShell({
@@ -16,6 +18,7 @@ export function AppShell({
   onLogout,
   onOpenDrive,
   onNavigateAdmin,
+  onBrandClick,
   children,
 }: PropsWithChildren<AppShellProps>) {
   const isAdminActive = currentPath.startsWith('/admin')
@@ -28,29 +31,53 @@ export function AppShell({
     .filter(Boolean)
     .join(' ')
 
+  const [leadingAction, setLeadingAction] = useState<ReactNode | null>(null)
+
+  const handleSetLeadingAction = useCallback((node: ReactNode | null) => {
+    setLeadingAction(node)
+  }, [])
+
+  const headerContextValue = useMemo(
+    () => ({
+      setLeadingAction: handleSetLeadingAction,
+    }),
+    [handleSetLeadingAction],
+  )
+
   return (
-    <div className="app-shell">
-      <header className="app-shell__header">
-        <div className="app-shell__brand">TestMate</div>
-        <BackgroundTaskTray />
-        {isAuthenticated && (
-          <nav aria-label="계정 메뉴" className="app-shell__nav">
-            <button type="button" className="app-shell__drive" onClick={onOpenDrive}>
-              구글 드라이브
+    <AppShellHeaderContext.Provider value={headerContextValue}>
+      <div className="app-shell">
+        <header className="app-shell__header">
+          <div className="app-shell__header-left">
+            {leadingAction ? (
+              <div className="app-shell__leading-action">{leadingAction}</div>
+            ) : null}
+            <button type="button" className="app-shell__brand-button" onClick={onBrandClick}>
+              <span className="app-shell__brand">TestMate</span>
             </button>
-            <button type="button" className={adminClasses} onClick={onNavigateAdmin}>
-              프롬프트 관리자
-            </button>
-            <button type="button" className="app-shell__logout" onClick={onLogout}>
-              로그아웃
-            </button>
-          </nav>
-        )}
-      </header>
+          </div>
+          <div className="app-shell__header-right">
+            <BackgroundTaskTray />
+            {isAuthenticated && (
+              <nav aria-label="계정 메뉴" className="app-shell__nav">
+                <button type="button" className="app-shell__drive" onClick={onOpenDrive}>
+                  구글 드라이브
+                </button>
+                <button type="button" className={adminClasses} onClick={onNavigateAdmin}>
+                  프롬프트 관리자
+                </button>
+                <button type="button" className="app-shell__logout" onClick={onLogout}>
+                  로그아웃
+                </button>
+              </nav>
+            )}
+          </div>
+        </header>
 
-      <main className="app-shell__main">{children}</main>
+        <main className="app-shell__main">{children}</main>
 
-      <footer className="app-shell__footer">© {new Date().getFullYear()} TTA AI Platform</footer>
-    </div>
+        <footer className="app-shell__footer">© {new Date().getFullYear()} TTA AI Platform</footer>
+      </div>
+    </AppShellHeaderContext.Provider>
   )
 }

--- a/frontend/src/app/components/AppShellHeaderContext.ts
+++ b/frontend/src/app/components/AppShellHeaderContext.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react'
+import type { ReactNode } from 'react'
+
+interface AppShellHeaderContextValue {
+  setLeadingAction: (node: ReactNode | null) => void
+}
+
+const AppShellHeaderContext = createContext<AppShellHeaderContextValue | undefined>(undefined)
+
+export function useAppShellHeader(): AppShellHeaderContextValue {
+  const context = useContext(AppShellHeaderContext)
+
+  if (!context) {
+    throw new Error('useAppShellHeader must be used within an AppShell component')
+  }
+
+  return context
+}
+
+export { AppShellHeaderContext }

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -9,6 +9,7 @@ import { Modal } from '../components/Modal'
 import { useBackgroundTasks } from '../app/background/BackgroundTaskContext'
 import { getBackendUrl } from '../config'
 import { navigate } from '../navigation'
+import { useAppShellHeader } from '../app/components/AppShellHeaderContext'
 
 type MenuItemId =
   | 'configuration-images'
@@ -324,6 +325,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const { startTask } = useBackgroundTasks()
   const [isSidebarOpen, setIsSidebarOpen] = useState(true)
   const isMountedRef = useRef(true)
+  const { setLeadingAction } = useAppShellHeader()
 
   const menuById = useMemo(() => {
     return MENU_ITEMS.reduce((acc, item) => {
@@ -1264,22 +1266,8 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   }, [])
 
   const sidebarToggleLabel = isSidebarOpen ? '사이드바 접기' : '사이드바 펼치기'
-  const pageClassName = [
-    'project-management-page',
-    isSidebarOpen ? 'project-management-page--sidebar-open' : 'project-management-page--sidebar-collapsed',
-    isTestcaseWorkflow ? 'project-management-page--preview' : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-  const contentClassName = [
-    'project-management-content',
-    isTestcaseWorkflow ? 'project-management-content--preview' : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-
-  return (
-    <div className={pageClassName}>
+  const sidebarToggleAction = useMemo(
+    () => (
       <button
         type="button"
         className="project-management-sidebar-toggle"
@@ -1317,7 +1305,33 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         </span>
         <span className="project-management-sr-only">{sidebarToggleLabel}</span>
       </button>
+    ),
+    [handleToggleSidebar, isSidebarOpen, sidebarToggleLabel],
+  )
 
+  useEffect(() => {
+    setLeadingAction(sidebarToggleAction)
+
+    return () => {
+      setLeadingAction(null)
+    }
+  }, [setLeadingAction, sidebarToggleAction])
+  const pageClassName = [
+    'project-management-page',
+    isSidebarOpen ? 'project-management-page--sidebar-open' : 'project-management-page--sidebar-collapsed',
+    isTestcaseWorkflow ? 'project-management-page--preview' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const contentClassName = [
+    'project-management-content',
+    isTestcaseWorkflow ? 'project-management-content--preview' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={pageClassName}>
       <aside
         id="project-management-sidebar"
         className="project-management-sidebar"

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -322,6 +322,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const performanceOverridesRef = useRef<Record<string, string> | null>(null)
   const [performanceModalState, setPerformanceModalState] = useState<PerformanceOSModalState | null>(null)
   const { startTask } = useBackgroundTasks()
+  const [isSidebarOpen, setIsSidebarOpen] = useState(true)
   const isMountedRef = useRef(true)
 
   const menuById = useMemo(() => {
@@ -352,6 +353,24 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
   const handleSelectAnotherProject = useCallback(() => {
     navigate('/projects')
   }, [])
+
+  const handleToggleSidebar = useCallback(() => {
+    setIsSidebarOpen((prev) => !prev)
+  }, [])
+
+  const handleCloseSidebar = useCallback(() => {
+    setIsSidebarOpen(false)
+  }, [])
+
+  const handleSelectMenuItem = useCallback(
+    (itemId: MenuItemId) => {
+      setActiveItem(itemId)
+      if (typeof window !== 'undefined' && window.innerWidth < 1024) {
+        setIsSidebarOpen(false)
+      }
+    },
+    [setActiveItem, setIsSidebarOpen],
+  )
 
   useEffect(() => {
     return () => {
@@ -1244,9 +1263,66 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
     }
   }, [])
 
+  const sidebarToggleLabel = isSidebarOpen ? '사이드바 접기' : '사이드바 펼치기'
+  const pageClassName = [
+    'project-management-page',
+    isSidebarOpen ? 'project-management-page--sidebar-open' : 'project-management-page--sidebar-collapsed',
+    isTestcaseWorkflow ? 'project-management-page--preview' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+  const contentClassName = [
+    'project-management-content',
+    isTestcaseWorkflow ? 'project-management-content--preview' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+
   return (
-    <div className="project-management-page">
-      <aside className="project-management-sidebar">
+    <div className={pageClassName}>
+      <button
+        type="button"
+        className="project-management-sidebar-toggle"
+        onClick={handleToggleSidebar}
+        aria-expanded={isSidebarOpen}
+        aria-controls="project-management-sidebar"
+        title={sidebarToggleLabel}
+      >
+        <span className="project-management-sidebar-toggle__icon" aria-hidden="true">
+          {isSidebarOpen ? (
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="15 6 9 12 15 18" />
+            </svg>
+          ) : (
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="4" y1="6" x2="20" y2="6" />
+              <line x1="4" y1="12" x2="20" y2="12" />
+              <line x1="4" y1="18" x2="16" y2="18" />
+            </svg>
+          )}
+        </span>
+        <span className="project-management-sr-only">{sidebarToggleLabel}</span>
+      </button>
+
+      <aside
+        id="project-management-sidebar"
+        className="project-management-sidebar"
+        aria-hidden={!isSidebarOpen}
+      >
         <div className="project-management-overview">
           <span className="project-management-overview__label">프로젝트</span>
           <strong className="project-management-overview__name">{projectName}</strong>
@@ -1267,7 +1343,7 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                   <button
                     type="button"
                     className="project-management-menu__button"
-                    onClick={() => setActiveItem(item.id)}
+                    onClick={() => handleSelectMenuItem(item.id)}
                     aria-current={isActive ? 'page' : undefined}
                   >
                     <span className="project-management-menu__label">{item.label}</span>
@@ -1280,7 +1356,15 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         </nav>
       </aside>
 
-      <main className="project-management-content" aria-label="프로젝트 관리 컨텐츠">
+      <button
+        type="button"
+        className="project-management-sidebar-backdrop"
+        aria-hidden="true"
+        tabIndex={-1}
+        onClick={handleCloseSidebar}
+      />
+
+      <main className={contentClassName} aria-label="프로젝트 관리 컨텐츠">
         <div className="project-management-content__inner">
           <div className="project-management-content__toolbar" role="navigation" aria-label="프로젝트 작업 메뉴">
             <button

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -1286,7 +1286,9 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               strokeLinecap="round"
               strokeLinejoin="round"
             >
-              <polyline points="15 6 9 12 15 18" />
+              <rect x="4" y="4" width="4" height="16" rx="1.5" />
+              <path d="M15 8L11 12L15 16" />
+              <line x1="20" y1="5" x2="20" y2="19" />
             </svg>
           ) : (
             <svg
@@ -1297,9 +1299,9 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
               strokeLinecap="round"
               strokeLinejoin="round"
             >
-              <line x1="4" y1="6" x2="20" y2="6" />
-              <line x1="4" y1="12" x2="20" y2="12" />
-              <line x1="4" y1="18" x2="16" y2="18" />
+              <rect x="4" y="4" width="4" height="16" rx="1.5" />
+              <path d="M10 8L14 12L10 16" />
+              <line x1="18" y1="5" x2="18" y2="19" />
             </svg>
           )}
         </span>


### PR DESCRIPTION
## Summary
- refactor the project management page layout so the sidebar anchors to the left edge with a dedicated toggle button and responsive behaviour
- expand the main project management content area to fill the available viewport beside the sidebar while preserving existing workflows
- add styling hooks and responsive rules so the full-bleed layout coexists with the global shell spacing

## Testing
- npm run lint *(fails: existing lint errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_690ca71134e8832e944d21737616aee3