### PR TITLE
Revamp shared layout chrome to match sample UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,28 +2,31 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.82) 0%, rgba(226, 232, 240, 0.95) 100%);
+  background: linear-gradient(180deg, #f6f8fc 0%, #eef2f8 100%);
 }
 
 .app-shell__header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 20;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+}
+
+.app-shell__header-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.25rem clamp(1.5rem, 4vw, 3.5rem);
-  background: rgba(15, 23, 42, 0.92);
-  color: white;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(12px);
+  gap: clamp(1rem, 3vw, 2rem);
+  padding: 0 clamp(1.5rem, 4vw, 3.5rem);
+  min-height: 4.25rem;
 }
 
 .app-shell__header-left {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .app-shell__leading-action {
@@ -32,103 +35,73 @@
 }
 
 .app-shell__brand-button {
-  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.9rem;
-  padding: 0.55rem 1.25rem 0.55rem 0.55rem;
+  gap: 0.75rem;
+  padding: 0.35rem 0.95rem 0.35rem 0.35rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.16) 0%, rgba(15, 23, 42, 0.28) 100%);
+  border: none;
+  background: transparent;
   color: inherit;
   font: inherit;
   cursor: pointer;
   text-align: left;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .app-shell__brand-button:hover,
 .app-shell__brand-button:focus-visible {
   transform: translateY(-1px);
-  border-color: rgba(148, 197, 255, 0.65);
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35) 0%, rgba(30, 64, 175, 0.65) 100%);
-  color: #f8fafc;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.18);
 }
 
 .app-shell__brand-button:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.75);
-  outline-offset: 3px;
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 4px;
 }
 
-.app-shell__brand-mark {
-  position: relative;
-  width: 2.45rem;
-  height: 2.45rem;
-  border-radius: 0.85rem;
+.app-shell__brand-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  overflow: hidden;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.95) 0%, rgba(59, 130, 246, 0.85) 100%);
-  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.35);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.85rem;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  box-shadow: 0 12px 28px rgba(37, 99, 235, 0.28);
 }
 
-.app-shell__brand-mark-glow {
-  position: absolute;
-  inset: -30%;
-  border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(224, 231, 255, 0.6), transparent 60%);
-  opacity: 0.8;
+.app-shell__brand-icon-mark {
+  width: 1.4rem;
+  height: 1.4rem;
 }
 
-.app-shell__brand-initials {
-  position: relative;
-  font-weight: 700;
-  font-size: 0.95rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #f8fafc;
-  text-shadow: 0 4px 12px rgba(15, 23, 42, 0.4);
-}
-
-.app-shell__brand-wordmark {
+.app-shell__brand-copy {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  line-height: 1;
+  gap: 0.15rem;
+  align-items: flex-start;
+  line-height: 1.1;
 }
 
-.app-shell__brand-text {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 0.3rem;
-  font-size: 1.32rem;
+.app-shell__brand-title {
+  font-size: 1.25rem;
   font-weight: 700;
-  letter-spacing: 0.015em;
-  color: #f1f5f9;
-  text-shadow: 0 8px 24px rgba(15, 23, 42, 0.4);
+  color: #0f172a;
 }
 
-.app-shell__brand-primary {
-  color: rgba(226, 232, 240, 0.92);
-}
-
-.app-shell__brand-highlight {
-  color: #bfdbfe;
-}
-
-.app-shell__brand-tagline {
-  font-size: 0.68rem;
+.app-shell__brand-subtitle {
+  font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  color: #64748b;
 }
 
 .app-shell__tasks {
   position: relative;
-  display: flex;
+  display: inline-flex;
   align-items: center;
 }
 
@@ -136,7 +109,71 @@
   margin-left: auto;
   display: inline-flex;
   align-items: center;
-  gap: 1.5rem;
+  gap: 1rem;
+}
+
+.app-shell__nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.app-shell__nav-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: #1f2937;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-shell__nav-button:hover,
+.app-shell__nav-button:focus-visible {
+  outline: none;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+}
+
+.app-shell__nav-button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.35);
+  outline-offset: 2px;
+}
+
+.app-shell__nav-button--ghost {
+  border-color: rgba(37, 99, 235, 0.18);
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
+}
+
+.app-shell__nav-button--ghost:hover,
+.app-shell__nav-button--ghost:focus-visible {
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(37, 99, 235, 0.3);
+  color: #1e3a8a;
+}
+
+.app-shell__nav-button--active {
+  background: linear-gradient(135deg, #1d4ed8, #2563eb);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 14px 26px rgba(37, 99, 235, 0.25);
+}
+
+.app-shell__nav-button--primary {
+  background: linear-gradient(135deg, #1e3a8a, #2563eb);
+  color: #ffffff;
+  border-color: transparent;
+  box-shadow: 0 14px 26px rgba(30, 64, 175, 0.22);
+}
+
+.app-shell__nav-button--primary:hover,
+.app-shell__nav-button--primary:focus-visible {
+  background: linear-gradient(135deg, #1e3a8a, #1d4ed8);
 }
 
 .app-shell__tasks-toggle {
@@ -145,53 +182,67 @@
   gap: 0.5rem;
   padding: 0.4rem 0.9rem;
   border-radius: 999px;
-  border: 1px solid rgba(226, 232, 240, 0.45);
-  background: rgba(15, 23, 42, 0.25);
-  color: rgba(226, 232, 240, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.9);
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .app-shell__tasks-toggle:hover,
-.app-shell__tasks-toggle:focus-visible,
-.app-shell__tasks-toggle--open {
-  background: rgba(59, 130, 246, 0.22);
-  border-color: rgba(226, 232, 240, 0.75);
-  color: #ffffff;
-  box-shadow: 0 10px 24px rgba(30, 64, 175, 0.35);
+.app-shell__tasks-toggle:focus-visible {
+  background: rgba(219, 234, 254, 0.8);
+  border-color: rgba(37, 99, 235, 0.45);
+  color: #1e3a8a;
+  box-shadow: 0 12px 24px rgba(148, 197, 255, 0.35);
 }
 
 .app-shell__tasks-toggle:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.85);
+  outline: 2px solid rgba(37, 99, 235, 0.45);
   outline-offset: 2px;
+}
+
+.app-shell__tasks-toggle--open {
+  background: rgba(219, 234, 254, 0.95);
+  border-color: rgba(59, 130, 246, 0.5);
+  color: #1e3a8a;
+  box-shadow: 0 14px 28px rgba(148, 197, 255, 0.45);
+}
+
+.app-shell__tasks-label {
+  font-size: 0.9rem;
 }
 
 .app-shell__tasks-count {
   min-width: 1.5rem;
   height: 1.5rem;
-  border-radius: 999px;
-  background: rgba(248, 113, 113, 0.92);
-  color: #ffffff;
-  font-size: 0.82rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.4rem;
+  border-radius: 999px;
+  padding: 0 0.35rem;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  font-size: 0.8rem;
+  font-weight: 600;
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.3);
 }
 
 .app-shell__tasks-panel {
   position: absolute;
-  top: calc(100% + 0.75rem);
+  top: calc(100% + 0.65rem);
   right: 0;
   width: min(420px, 85vw);
   max-height: 60vh;
-  padding: 1rem;
+  padding: 1.2rem;
   border-radius: 18px;
-  background: rgba(15, 23, 42, 0.96);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
-  backdrop-filter: blur(18px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.98);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.18);
+  backdrop-filter: blur(12px);
   overflow-y: auto;
+  z-index: 5;
 }
 
 .app-shell__tasks-list {
@@ -200,30 +251,30 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .app-shell__task {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.75rem;
-  border-radius: 14px;
-  background: rgba(30, 41, 59, 0.75);
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  background: #f8fafc;
   border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .app-shell__task-main {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
   min-width: 0;
 }
 
 .app-shell__task-title {
   font-weight: 600;
   font-size: 0.95rem;
-  color: #e2e8f0;
+  color: #0f172a;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -234,51 +285,51 @@
   flex-wrap: wrap;
   gap: 0.35rem 0.65rem;
   font-size: 0.82rem;
-  color: rgba(203, 213, 225, 0.92);
+  color: #475569;
 }
 
 .app-shell__task-status-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.2rem 0.6rem;
+  padding: 0.2rem 0.65rem;
   border-radius: 999px;
   font-weight: 600;
 }
 
 .app-shell__task-status-badge--running {
-  background: rgba(59, 130, 246, 0.3);
-  color: #bfdbfe;
+  background: rgba(59, 130, 246, 0.16);
+  color: #1e3a8a;
 }
 
 .app-shell__task-status-badge--succeeded {
-  background: rgba(34, 197, 94, 0.28);
-  color: #bbf7d0;
+  background: rgba(34, 197, 94, 0.16);
+  color: #166534;
 }
 
 .app-shell__task-status-badge--failed {
-  background: rgba(239, 68, 68, 0.28);
-  color: #fecaca;
+  background: rgba(239, 68, 68, 0.16);
+  color: #b91c1c;
 }
 
 .app-shell__task-status-badge--cancelled {
-  background: rgba(148, 163, 184, 0.28);
-  color: #e2e8f0;
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
 }
 
 .app-shell__task-message {
-  font-size: 0.8rem;
-  color: rgba(226, 232, 240, 0.85);
+  font-size: 0.82rem;
+  color: #475569;
 }
 
 .app-shell__task-warning {
-  font-size: 0.8rem;
-  color: rgba(251, 191, 36, 0.95);
+  font-size: 0.82rem;
+  color: #d97706;
 }
 
 .app-shell__task-error {
-  font-size: 0.8rem;
-  color: rgba(248, 113, 113, 0.95);
+  font-size: 0.82rem;
+  color: #b91c1c;
 }
 
 .app-shell__task-actions {
@@ -289,142 +340,36 @@
 }
 
 .app-shell__task-button {
-  padding: 0.35rem 0.8rem;
+  padding: 0.35rem 0.85rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(148, 163, 184, 0.12);
-  color: #e2e8f0;
+  border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(59, 130, 246, 0.08);
+  color: #1d4ed8;
   font-size: 0.82rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .app-shell__task-button:hover,
 .app-shell__task-button:focus-visible {
-  background: rgba(148, 163, 184, 0.24);
-  border-color: rgba(226, 232, 240, 0.75);
-  color: #ffffff;
+  background: rgba(59, 130, 246, 0.18);
+  border-color: rgba(37, 99, 235, 0.35);
+  color: #1e3a8a;
+  box-shadow: 0 10px 20px rgba(148, 197, 255, 0.28);
 }
 
 .app-shell__task-button--dismiss {
   background: transparent;
-  border-color: rgba(148, 163, 184, 0.25);
-  color: rgba(226, 232, 240, 0.75);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #64748b;
 }
 
 .app-shell__task-button--dismiss:hover,
 .app-shell__task-button--dismiss:focus-visible {
-  background: rgba(248, 113, 113, 0.22);
-  border-color: rgba(248, 113, 113, 0.6);
-  color: #fee2e2;
-}
-
-.app-shell__nav {
-  display: flex;
-  align-items: center;
-  font-size: 0.95rem;
-}
-
-.app-shell__link-button {
-  position: relative;
-  margin-left: 1rem;
-  padding: 0.35rem 0;
-  border: none;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-}
-
-.app-shell__link-button:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.85);
-  outline-offset: 4px;
-}
-
-.app-shell__link {
-  position: relative;
-  color: rgba(226, 232, 240, 0.9);
-  text-decoration: none;
-  font-weight: 600;
-  transition: color 0.2s ease;
-}
-
-.app-shell__link::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -0.45rem;
-  width: 100%;
-  height: 2px;
-  border-radius: 999px;
-  background: rgba(226, 232, 240, 0.65);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.2s ease;
-}
-
-.app-shell__link:hover {
-  color: white;
-}
-
-.app-shell__link:hover::after,
-.app-shell__link--active::after {
-  transform: scaleX(1);
-}
-
-.app-shell__link--active {
-  color: white;
-}
-
-.app-shell__drive,
-.app-shell__logout {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.45rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(226, 232, 240, 0.55);
-  background: transparent;
-  color: rgba(226, 232, 240, 0.92);
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.app-shell__drive {
-  margin-right: 0.75rem;
-  border-color: rgba(226, 232, 240, 0.75);
-  background: rgba(59, 130, 246, 0.14);
-  color: #ffffff;
-  backdrop-filter: blur(6px);
-}
-
-.app-shell__drive:hover,
-.app-shell__drive:focus-visible {
-  background: rgba(59, 130, 246, 0.24);
-  border-color: rgba(226, 232, 240, 0.9);
-  color: #ffffff;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
-}
-
-.app-shell__logout:hover,
-.app-shell__logout:focus-visible {
-  background: rgba(226, 232, 240, 0.18);
-  color: #ffffff;
-  border-color: rgba(226, 232, 240, 0.85);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
-}
-
-.app-shell__logout {
-  margin-left: 1.1rem;
-}
-
-.app-shell__drive:focus-visible,
-.app-shell__logout:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.9);
-  outline-offset: 2px;
+  background: rgba(248, 113, 113, 0.16);
+  border-color: rgba(248, 113, 113, 0.4);
+  color: #b91c1c;
 }
 
 .app-shell__main {
@@ -1556,7 +1501,7 @@
 }
 
 .project-management-page {
-  --project-management-sidebar-width: 280px;
+  --project-management-sidebar-width: 288px;
   position: relative;
   display: grid;
   grid-template-columns: var(--project-management-sidebar-width) minmax(0, 1fr);
@@ -1564,7 +1509,7 @@
   min-width: 0;
   width: calc(100% + (2 * var(--app-shell-main-padding-x)));
   margin: calc(-1 * var(--app-shell-main-padding-y)) calc(-1 * var(--app-shell-main-padding-x));
-  background: #f8fafc;
+  background: linear-gradient(180deg, #f6f8fc 0%, #eef2f8 100%);
   min-height: calc(100vh - (2 * var(--app-shell-main-padding-y)));
   overflow: hidden;
   transition: grid-template-columns 0.3s ease;
@@ -1575,22 +1520,26 @@
 }
 
 .project-management-sidebar-toggle {
-  width: 42px;
-  height: 42px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  position: fixed;
+  top: clamp(6rem, 8vw, 7.5rem);
+  z-index: 4;
+  width: 36px;
+  height: 36px;
   border-radius: 999px;
-  background: rgba(15, 23, 42, 0.6);
-  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.95);
+  color: #1d4ed8;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
-  position: fixed;
-  top: 500px;
-  z-index: 3;
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.12);
   --project-management-sidebar-toggle-x: 0;
   --project-management-sidebar-toggle-y: -50%;
+  transform: translate(
+    var(--project-management-sidebar-toggle-x),
+    var(--project-management-sidebar-toggle-y)
+  );
   transition:
     left 0.3s ease,
     transform 0.3s ease,
@@ -1598,10 +1547,6 @@
     color 0.2s ease,
     box-shadow 0.2s ease,
     border-color 0.2s ease;
-  transform: translate(
-    var(--project-management-sidebar-toggle-x),
-    var(--project-management-sidebar-toggle-y)
-  );
 }
 
 .project-management-sidebar-toggle:hover,
@@ -1612,17 +1557,16 @@
       var(--project-management-sidebar-toggle-y)
     )
     translateY(-1px);
-  background: rgba(30, 41, 59, 0.9);
-  color: #f8fafc;
-  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.28);
-  border-color: rgba(226, 232, 240, 0.55);
+  background: rgba(219, 234, 254, 0.95);
+  color: #1e3a8a;
+  border-color: rgba(59, 130, 246, 0.45);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.22);
 }
 
 .project-management-sidebar-toggle:focus-visible {
-  outline: 3px solid rgba(59, 130, 246, 0.45);
+  outline: 3px solid rgba(59, 130, 246, 0.35);
   outline-offset: 2px;
 }
-
 
 .project-management-page--sidebar-open .project-management-sidebar-toggle {
   left: var(--project-management-sidebar-width);
@@ -1630,7 +1574,7 @@
 }
 
 .project-management-page--sidebar-collapsed .project-management-sidebar-toggle {
-  left: -1.4rem;
+  left: -1.1rem;
   --project-management-sidebar-toggle-x: 0;
 }
 
@@ -1641,8 +1585,8 @@
 }
 
 .project-management-sidebar-toggle__icon svg {
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   stroke-width: 1.8;
 }
 
@@ -1661,7 +1605,7 @@
 .project-management-sidebar-backdrop {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  background: rgba(15, 23, 42, 0.28);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
@@ -1680,24 +1624,19 @@
   }
 }
 
-.project-management-sidebar__inner-follow{
-  position: fixed;
-  top : 20px;
-}
-
 .project-management-sidebar {
   position: relative;
   z-index: 2;
   width: var(--project-management-sidebar-width);
+  background: rgba(255, 255, 255, 0.96);
+  border-right: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 4px 0 24px rgba(15, 23, 42, 0.08);
   display: flex;
   flex-direction: column;
-  gap: 1.75rem;
-  padding: 2.5rem 2rem;
-  background: #0f172a;
-  color: #e2e8f0;
+  padding: 2.25rem 1.75rem;
+  color: #0f172a;
   transition: transform 0.3s ease, opacity 0.3s ease;
-  box-shadow: 1px 0 0 rgba(15, 23, 42, 0.4);
-  min-height: 100%;
+  backdrop-filter: blur(10px);
 }
 
 .project-management-page--sidebar-collapsed .project-management-sidebar {
@@ -1712,33 +1651,45 @@
   pointer-events: auto;
 }
 
+.project-management-sidebar__inner {
+  position: sticky;
+  top: clamp(5.5rem, 8vw, 7rem);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
 .project-management-overview {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
-  margin-bottom: 10px;
+  gap: 0.65rem;
+  padding: 1.2rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(59, 130, 246, 0.18);
+  background: linear-gradient(135deg, rgba(219, 234, 254, 0.6), rgba(255, 255, 255, 0.9));
+  box-shadow: 0 12px 24px rgba(59, 130, 246, 0.12);
 }
 
 .project-management-overview__label {
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   font-weight: 600;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.6);
+  color: #64748b;
 }
 
 .project-management-overview__name {
-  font-size: 1.4rem;
+  font-size: 1.25rem;
   font-weight: 700;
-  line-height: 1.2;
-  color: #ffffff;
+  line-height: 1.3;
+  color: #0f172a;
   word-break: keep-all;
 }
 
 .project-management-menu {
-  flex: 1;
   display: flex;
   flex-direction: column;
+  gap: 0.6rem;
 }
 
 .project-management-menu__list {
@@ -1747,59 +1698,127 @@
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .project-management-menu__item {
-  border-radius: 14px;
+  border-radius: 16px;
   overflow: hidden;
 }
 
 .project-management-menu__button {
   width: 100%;
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.35rem;
-  padding: 0.9rem 1rem;
-  border: none;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0.8rem 0.95rem;
+  border: 1px solid transparent;
   border-radius: inherit;
   background: transparent;
-  color: rgba(226, 232, 240, 0.75);
+  color: #1e293b;
   font: inherit;
   text-align: left;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .project-management-menu__button:hover,
 .project-management-menu__button:focus-visible {
   outline: none;
-  background: rgba(148, 163, 184, 0.18);
-  color: #ffffff;
-  transform: translateX(4px);
+  background: rgba(219, 234, 254, 0.6);
+  border-color: rgba(59, 130, 246, 0.25);
+  color: #1e40af;
+  box-shadow: 0 10px 18px rgba(59, 130, 246, 0.18);
 }
 
-.project-management-menu__item--active .project-management-menu__button {
-  background: rgba(59, 130, 246, 0.32);
-  color: #ffffff;
-  box-shadow: inset 0 0 0 1px rgba(148, 197, 255, 0.35);
-  transform: none;
+.project-management-menu__icon {
+  width: 2.4rem;
+  height: 2.4rem;
+  border-radius: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #eef2f8;
+  color: #1e40af;
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+}
+
+.project-management-menu__icon-letter {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: inherit;
+}
+
+.project-management-menu__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
+}
+
+.project-management-menu__helper {
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #64748b;
 }
 
 .project-management-menu__label {
   font-weight: 600;
+  font-size: 1rem;
+  color: inherit;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-.project-management-menu__helper {
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.6);
+.project-management-menu__chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(148, 163, 184, 0.9);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.project-management-menu__chevron svg {
+  width: 18px;
+  height: 18px;
+}
+
+.project-management-menu__item--active .project-management-menu__button {
+  background: rgba(219, 234, 254, 0.95);
+  border-color: rgba(59, 130, 246, 0.45);
+  color: #1e3a8a;
+  box-shadow: 0 14px 28px rgba(59, 130, 246, 0.2);
+}
+
+.project-management-menu__item--active .project-management-menu__icon {
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #ffffff;
+  box-shadow: 0 10px 18px rgba(59, 130, 246, 0.25);
+}
+
+.project-management-menu__item--active .project-management-menu__chevron {
+  color: #1e3a8a;
+  transform: translateX(2px);
 }
 
 .project-management-menu__item--active .project-management-menu__helper {
-  color: rgba(255, 255, 255, 0.9);
+  color: #1e3a8a;
+}
+
+@media (max-width: 1024px) {
+  .project-management-sidebar {
+    padding: 2rem 1.5rem;
+  }
+
+  .project-management-sidebar__inner {
+    position: static;
+    top: auto;
+  }
 }
 
 .project-management-content {

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -24,9 +24,9 @@ export function AppShell({
   const isAdminActive = currentPath.startsWith('/admin')
 
   const adminClasses = [
-    'app-shell__link',
-    'app-shell__link-button',
-    isAdminActive ? 'app-shell__link--active' : '',
+    'app-shell__nav-button',
+    'app-shell__nav-button--ghost',
+    isAdminActive ? 'app-shell__nav-button--active' : '',
   ]
     .filter(Boolean)
     .join(' ')
@@ -48,44 +48,63 @@ export function AppShell({
     <AppShellHeaderContext.Provider value={headerContextValue}>
       <div className="app-shell">
         <header className="app-shell__header">
-          <div className="app-shell__header-left">
-            {leadingAction ? (
-              <div className="app-shell__leading-action">{leadingAction}</div>
-            ) : null}
-            <button
-              type="button"
-              className="app-shell__brand-button"
-              onClick={onBrandClick}
-              aria-label="프로젝트 선택 화면으로 이동"
-            >
-              <span className="app-shell__brand-mark" aria-hidden="true">
-                <span className="app-shell__brand-mark-glow" />
-                <span className="app-shell__brand-initials">TM</span>
-              </span>
-              <span className="app-shell__brand-wordmark">
-                <span className="app-shell__brand-text">
-                  <span className="app-shell__brand-primary">Test</span>
-                  <span className="app-shell__brand-highlight">Mate</span>
+          <div className="app-shell__header-inner">
+            <div className="app-shell__header-left">
+              {leadingAction ? (
+                <div className="app-shell__leading-action">{leadingAction}</div>
+              ) : null}
+              <button
+                type="button"
+                className="app-shell__brand-button"
+                onClick={onBrandClick}
+                aria-label="프로젝트 선택 화면으로 이동"
+              >
+                <span className="app-shell__brand-icon" aria-hidden="true">
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="app-shell__brand-icon-mark"
+                  >
+                    <path
+                      d="M4 12.5L9 17.5L20 6.5"
+                      stroke="currentColor"
+                      strokeWidth="2.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
                 </span>
-                <span className="app-shell__brand-tagline">QA Workspace</span>
-              </span>
-            </button>
-          </div>
-          <div className="app-shell__header-right">
-            <BackgroundTaskTray />
-            {isAuthenticated && (
-              <nav aria-label="계정 메뉴" className="app-shell__nav">
-                <button type="button" className="app-shell__drive" onClick={onOpenDrive}>
-                  구글 드라이브
-                </button>
-                <button type="button" className={adminClasses} onClick={onNavigateAdmin}>
-                  프롬프트 관리자
-                </button>
-                <button type="button" className="app-shell__logout" onClick={onLogout}>
-                  로그아웃
-                </button>
-              </nav>
-            )}
+                <span className="app-shell__brand-copy">
+                  <span className="app-shell__brand-title">TestMate</span>
+                  <span className="app-shell__brand-subtitle">QA Workspace</span>
+                </span>
+              </button>
+            </div>
+            <div className="app-shell__header-right">
+              <BackgroundTaskTray />
+              {isAuthenticated && (
+                <nav aria-label="계정 메뉴" className="app-shell__nav">
+                  <button
+                    type="button"
+                    className="app-shell__nav-button app-shell__nav-button--ghost"
+                    onClick={onOpenDrive}
+                  >
+                    구글 드라이브
+                  </button>
+                  <button type="button" className={adminClasses} onClick={onNavigateAdmin}>
+                    프롬프트 관리자
+                  </button>
+                  <button
+                    type="button"
+                    className="app-shell__nav-button app-shell__nav-button--primary"
+                    onClick={onLogout}
+                  >
+                    로그아웃
+                  </button>
+                </nav>
+              )}
+            </div>
           </div>
         </header>
 

--- a/frontend/src/components/layout/BackgroundTaskTray.tsx
+++ b/frontend/src/components/layout/BackgroundTaskTray.tsx
@@ -39,8 +39,10 @@ export function BackgroundTaskTray() {
         aria-expanded={isOpen}
         aria-haspopup="dialog"
       >
-        작업 현황
-        <span className="app-shell__tasks-count">{runningCount}</span>
+        <span className="app-shell__tasks-label">작업 현황</span>
+        <span className="app-shell__tasks-count" aria-live="polite">
+          {runningCount}
+        </span>
       </button>
 
       {isOpen && (

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -1325,38 +1325,56 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
         className="project-management-sidebar"
         aria-hidden={!isSidebarOpen}
       >
-        <div className="project-management-sidebar__inner-follow" >
-        <div className="project-management-overview">
-          <span className="project-management-overview__label">프로젝트</span>
-          <strong className="project-management-overview__name">{projectName}</strong>
-        </div>
+        <div className="project-management-sidebar__inner">
+          <div className="project-management-overview">
+            <span className="project-management-overview__label">프로젝트</span>
+            <strong className="project-management-overview__name">{projectName}</strong>
+          </div>
 
-        <nav aria-label="프로젝트 관리 메뉴" className="project-management-menu">
-          <ul className="project-management-menu__list">
-            {MENU_ITEMS.map((item) => {
-              const isActive = activeItem === item.id
+          <nav aria-label="프로젝트 관리 메뉴" className="project-management-menu">
+            <ul className="project-management-menu__list">
+              {MENU_ITEMS.map((item) => {
+                const isActive = activeItem === item.id
+                const helperInitial = item.eyebrow?.[0] ?? ''
 
-              return (
-                <li
-                  key={item.id}
-                  className={`project-management-menu__item${
-                    isActive ? ' project-management-menu__item--active' : ''
-                  }`}
-                >
-                  <button
-                    type="button"
-                    className="project-management-menu__button"
-                    onClick={() => handleSelectMenuItem(item.id)}
-                    aria-current={isActive ? 'page' : undefined}
+                return (
+                  <li
+                    key={item.id}
+                    className={`project-management-menu__item${
+                      isActive ? ' project-management-menu__item--active' : ''
+                    }`}
                   >
-                    <span className="project-management-menu__label">{item.label}</span>
-                    <span className="project-management-menu__helper">{item.eyebrow}</span>
-                  </button>
-                </li>
-              )
-            })}
-          </ul>
-        </nav>
+                    <button
+                      type="button"
+                      className="project-management-menu__button"
+                      onClick={() => handleSelectMenuItem(item.id)}
+                      aria-current={isActive ? 'page' : undefined}
+                    >
+                      <span className="project-management-menu__icon" aria-hidden="true">
+                        <span className="project-management-menu__icon-letter">{helperInitial}</span>
+                      </span>
+                      <span className="project-management-menu__text">
+                        <span className="project-management-menu__helper">{item.eyebrow}</span>
+                        <span className="project-management-menu__label">{item.label}</span>
+                      </span>
+                      <span className="project-management-menu__chevron" aria-hidden="true">
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="1.5"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M9 6L15 12L9 18" />
+                        </svg>
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
         </div>
       </aside>
 


### PR DESCRIPTION
## Summary
- restyled the top app shell header with the new TestMate brand treatment and consistent navigation buttons
- refreshed the background task tray presentation to align with the lighter header styling
- redesigned the project management sidebar markup and styles so the menu matches the sample UI structure

## Testing
- npm run build *(fails: TypeScript cannot resolve vitest/testing-library modules that are only used by test files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f6727e7c48330bbd3fca2abeb4a7d)