### PR TITLE
Revamp app shell with top bar and sidebar navigation

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,44 +2,64 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(180deg, rgba(241, 245, 249, 0.82) 0%, rgba(226, 232, 240, 0.95) 100%);
+  background: linear-gradient(180deg, rgba(239, 246, 255, 0.85) 0%, rgba(248, 250, 252, 0.95) 100%);
+  color: #0f172a;
 }
 
-.app-shell__header {
+.app-shell__topbar {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  padding: 1.25rem clamp(1.5rem, 4vw, 3.5rem);
-  background: rgba(15, 23, 42, 0.92);
-  color: white;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
-  backdrop-filter: blur(12px);
+  padding: 1rem clamp(1.5rem, 4vw, 3.25rem);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 14px 24px rgba(15, 23, 42, 0.08);
 }
 
-.app-shell__header-left {
+.app-shell__topbar-left {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.app-shell__topbar-leading {
   display: inline-flex;
   align-items: center;
   gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(59, 130, 246, 0.12);
+  color: #1e293b;
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
-.app-shell__leading-action {
+.app-shell__topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.app-shell__account-actions {
   display: inline-flex;
   align-items: center;
+  gap: 0.75rem;
 }
 
 .app-shell__brand-button {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 0.9rem;
-  padding: 0.55rem 1.25rem 0.55rem 0.55rem;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: linear-gradient(135deg, rgba(59, 130, 246, 0.16) 0%, rgba(15, 23, 42, 0.28) 100%);
+  gap: 0.85rem;
+  padding: 0.6rem 1.2rem 0.6rem 0.6rem;
+  border-radius: 16px;
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.12) 0%, rgba(14, 165, 233, 0.12) 100%);
   color: inherit;
   font: inherit;
   cursor: pointer;
@@ -50,52 +70,51 @@
 .app-shell__brand-button:hover,
 .app-shell__brand-button:focus-visible {
   transform: translateY(-1px);
-  border-color: rgba(148, 197, 255, 0.65);
-  background: linear-gradient(135deg, rgba(96, 165, 250, 0.35) 0%, rgba(30, 64, 175, 0.65) 100%);
-  color: #f8fafc;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.35);
+  border-color: rgba(37, 99, 235, 0.55);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.2) 0%, rgba(14, 165, 233, 0.22) 100%);
+  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.18);
 }
 
 .app-shell__brand-button:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.75);
+  outline: 2px solid rgba(96, 165, 250, 0.6);
   outline-offset: 3px;
 }
 
 .app-shell__brand-mark {
   position: relative;
-  width: 2.45rem;
-  height: 2.45rem;
-  border-radius: 0.85rem;
+  width: 2.35rem;
+  height: 2.35rem;
+  border-radius: 0.8rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   overflow: hidden;
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.95) 0%, rgba(59, 130, 246, 0.85) 100%);
-  box-shadow: 0 16px 32px rgba(59, 130, 246, 0.35);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9) 0%, rgba(37, 99, 235, 0.9) 100%);
+  box-shadow: 0 10px 20px rgba(59, 130, 246, 0.35);
 }
 
 .app-shell__brand-mark-glow {
   position: absolute;
   inset: -30%;
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(224, 231, 255, 0.6), transparent 60%);
-  opacity: 0.8;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.55), transparent 60%);
+  opacity: 0.9;
 }
 
 .app-shell__brand-initials {
   position: relative;
   font-weight: 700;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #f8fafc;
-  text-shadow: 0 4px 12px rgba(15, 23, 42, 0.4);
+  text-shadow: 0 4px 12px rgba(15, 23, 42, 0.35);
 }
 
 .app-shell__brand-wordmark {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
   line-height: 1;
 }
 
@@ -103,27 +122,26 @@
   display: inline-flex;
   align-items: baseline;
   gap: 0.3rem;
-  font-size: 1.32rem;
+  font-size: 1.28rem;
   font-weight: 700;
   letter-spacing: 0.015em;
-  color: #f1f5f9;
-  text-shadow: 0 8px 24px rgba(15, 23, 42, 0.4);
+  color: #0f172a;
 }
 
 .app-shell__brand-primary {
-  color: rgba(226, 232, 240, 0.92);
+  color: #0f172a;
 }
 
 .app-shell__brand-highlight {
-  color: #bfdbfe;
+  color: #1d4ed8;
 }
 
 .app-shell__brand-tagline {
   font-size: 0.68rem;
   font-weight: 600;
-  letter-spacing: 0.28em;
+  letter-spacing: 0.24em;
   text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.85);
+  color: #60a5fa;
 }
 
 .app-shell__tasks {
@@ -132,38 +150,31 @@
   align-items: center;
 }
 
-.app-shell__header-right {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 1.5rem;
-}
-
 .app-shell__tasks-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.9rem;
+  gap: 0.45rem;
+  padding: 0.45rem 0.9rem;
   border-radius: 999px;
-  border: 1px solid rgba(226, 232, 240, 0.45);
-  background: rgba(15, 23, 42, 0.25);
-  color: rgba(226, 232, 240, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.6);
+  color: #1f2937;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
 }
 
 .app-shell__tasks-toggle:hover,
 .app-shell__tasks-toggle:focus-visible,
 .app-shell__tasks-toggle--open {
-  background: rgba(59, 130, 246, 0.22);
-  border-color: rgba(226, 232, 240, 0.75);
-  color: #ffffff;
-  box-shadow: 0 10px 24px rgba(30, 64, 175, 0.35);
+  background: rgba(59, 130, 246, 0.16);
+  border-color: rgba(37, 99, 235, 0.45);
+  color: #1d4ed8;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.16);
 }
 
 .app-shell__tasks-toggle:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.85);
+  outline: 2px solid rgba(96, 165, 250, 0.5);
   outline-offset: 2px;
 }
 
@@ -171,13 +182,14 @@
   min-width: 1.5rem;
   height: 1.5rem;
   border-radius: 999px;
-  background: rgba(248, 113, 113, 0.92);
+  background: linear-gradient(135deg, rgba(248, 113, 113, 0.92), rgba(239, 68, 68, 0.92));
   color: #ffffff;
   font-size: 0.82rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   padding: 0 0.4rem;
+  font-weight: 600;
 }
 
 .app-shell__tasks-panel {
@@ -186,10 +198,10 @@
   right: 0;
   width: min(420px, 85vw);
   max-height: 60vh;
-  padding: 1rem;
+  padding: 1.1rem;
   border-radius: 18px;
-  background: rgba(15, 23, 42, 0.96);
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.35);
+  background: rgba(15, 23, 42, 0.94);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.32);
   backdrop-filter: blur(18px);
   overflow-y: auto;
 }
@@ -207,9 +219,9 @@
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.75rem;
+  padding: 0.85rem;
   border-radius: 14px;
-  background: rgba(30, 41, 59, 0.75);
+  background: rgba(30, 41, 59, 0.78);
   border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
@@ -289,7 +301,7 @@
 }
 
 .app-shell__task-button {
-  padding: 0.35rem 0.8rem;
+  padding: 0.4rem 0.85rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.35);
   background: rgba(148, 163, 184, 0.12);
@@ -320,121 +332,179 @@
   color: #fee2e2;
 }
 
-.app-shell__nav {
-  display: flex;
-  align-items: center;
-  font-size: 0.95rem;
-}
-
-.app-shell__link-button {
-  position: relative;
-  margin-left: 1rem;
-  padding: 0.35rem 0;
-  border: none;
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-}
-
-.app-shell__link-button:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.85);
-  outline-offset: 4px;
-}
-
-.app-shell__link {
-  position: relative;
-  color: rgba(226, 232, 240, 0.9);
-  text-decoration: none;
-  font-weight: 600;
-  transition: color 0.2s ease;
-}
-
-.app-shell__link::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  bottom: -0.45rem;
-  width: 100%;
-  height: 2px;
-  border-radius: 999px;
-  background: rgba(226, 232, 240, 0.65);
-  transform: scaleX(0);
-  transform-origin: left;
-  transition: transform 0.2s ease;
-}
-
-.app-shell__link:hover {
-  color: white;
-}
-
-.app-shell__link:hover::after,
-.app-shell__link--active::after {
-  transform: scaleX(1);
-}
-
-.app-shell__link--active {
-  color: white;
-}
-
 .app-shell__drive,
 .app-shell__logout {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.45rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(226, 232, 240, 0.55);
-  background: transparent;
-  color: rgba(226, 232, 240, 0.92);
+  padding: 0.45rem 1.05rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.75);
+  color: #1f2937;
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .app-shell__drive {
-  margin-right: 0.75rem;
-  border-color: rgba(226, 232, 240, 0.75);
-  background: rgba(59, 130, 246, 0.14);
-  color: #ffffff;
-  backdrop-filter: blur(6px);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.16), rgba(59, 130, 246, 0.12));
+  border-color: rgba(59, 130, 246, 0.35);
+  color: #1d4ed8;
 }
 
 .app-shell__drive:hover,
 .app-shell__drive:focus-visible {
-  background: rgba(59, 130, 246, 0.24);
-  border-color: rgba(226, 232, 240, 0.9);
-  color: #ffffff;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.28);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.28), rgba(14, 165, 233, 0.24));
+  border-color: rgba(37, 99, 235, 0.55);
+  color: #1e3a8a;
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.18);
 }
 
 .app-shell__logout:hover,
 .app-shell__logout:focus-visible {
-  background: rgba(226, 232, 240, 0.18);
-  color: #ffffff;
-  border-color: rgba(226, 232, 240, 0.85);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
-}
-
-.app-shell__logout {
-  margin-left: 1.1rem;
+  background: rgba(148, 163, 184, 0.2);
+  border-color: rgba(100, 116, 139, 0.45);
+  color: #0f172a;
+  box-shadow: 0 10px 20px rgba(100, 116, 139, 0.15);
 }
 
 .app-shell__drive:focus-visible,
 .app-shell__logout:focus-visible {
-  outline: 2px solid rgba(226, 232, 240, 0.9);
+  outline: 2px solid rgba(96, 165, 250, 0.5);
+  outline-offset: 2px;
+}
+
+.app-shell__layout {
+  flex: 1;
+  display: flex;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  padding: clamp(1.5rem, 4vw, 3rem);
+  align-items: flex-start;
+}
+
+.app-shell__sidebar {
+  width: min(280px, 28vw);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.8rem 1.6rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow:
+    0 24px 48px rgba(15, 23, 42, 0.08),
+    0 2px 12px rgba(15, 23, 42, 0.05);
+  position: sticky;
+  top: calc(5rem + 1.5rem);
+}
+
+.app-shell__sidebar-heading {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #64748b;
+  margin-bottom: 0.9rem;
+  font-weight: 700;
+}
+
+.app-shell__sidebar-links {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.app-shell__sidebar-link {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 20px;
+  border: 1px solid transparent;
+  background: rgba(248, 250, 252, 0.6);
+  color: #0f172a;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.app-shell__sidebar-link:hover,
+.app-shell__sidebar-link:focus-visible {
+  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(59, 130, 246, 0.12);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.12);
+  transform: translateY(-1px);
+}
+
+.app-shell__sidebar-link:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.5);
+  outline-offset: 2px;
+}
+
+.app-shell__sidebar-link--active {
+  border-color: rgba(37, 99, 235, 0.55);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.2));
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.16);
+}
+
+.app-shell__sidebar-link-label {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.app-shell__sidebar-link-description {
+  font-size: 0.85rem;
+  color: #475569;
+  line-height: 1.5;
+}
+
+.app-shell__sidebar-footer {
+  margin-top: auto;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.app-shell__sidebar-footer-link {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(59, 130, 246, 0.45);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.18), rgba(14, 165, 233, 0.18));
+  color: #1d4ed8;
+  font-size: 0.98rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.app-shell__sidebar-footer-link:hover,
+.app-shell__sidebar-footer-link:focus-visible {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.28), rgba(14, 165, 233, 0.28));
+  border-color: rgba(37, 99, 235, 0.55);
+  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.18);
+}
+
+.app-shell__sidebar-footer-link:focus-visible {
+  outline: 2px solid rgba(96, 165, 250, 0.55);
   outline-offset: 2px;
 }
 
 .app-shell__main {
-  --app-shell-main-padding-x: clamp(1.5rem, 4vw, 3.5rem);
-  --app-shell-main-padding-y: clamp(2rem, 4vw, 4rem);
   flex: 1;
+  min-width: 0;
   display: flex;
   align-items: stretch;
   justify-content: center;
-  padding: var(--app-shell-main-padding-y) var(--app-shell-main-padding-x);
+  padding: 0;
 }
 
 .app-shell__footer {

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState, type PropsWithChildren, type ReactNode } from 'react'
 
+import { navigate } from '../../navigation'
 import { BackgroundTaskTray } from '../../components/layout/BackgroundTaskTray'
 import { AppShellHeaderContext } from './AppShellHeaderContext'
 
@@ -12,6 +13,22 @@ interface AppShellProps {
   onBrandClick: () => void
 }
 
+interface SidebarLink {
+  label: string
+  description: string
+  path: string
+  isActive: (currentPath: string) => boolean
+}
+
+const SIDEBAR_LINKS: SidebarLink[] = [
+  {
+    label: '프로젝트 허브',
+    description: '프로젝트별 산출물과 히스토리를 관리합니다.',
+    path: '/projects',
+    isActive: (path) => path === '/projects' || path.startsWith('/projects/'),
+  },
+]
+
 export function AppShell({
   isAuthenticated,
   currentPath,
@@ -21,16 +38,6 @@ export function AppShell({
   onBrandClick,
   children,
 }: PropsWithChildren<AppShellProps>) {
-  const isAdminActive = currentPath.startsWith('/admin')
-
-  const adminClasses = [
-    'app-shell__link',
-    'app-shell__link-button',
-    isAdminActive ? 'app-shell__link--active' : '',
-  ]
-    .filter(Boolean)
-    .join(' ')
-
   const [leadingAction, setLeadingAction] = useState<ReactNode | null>(null)
 
   const handleSetLeadingAction = useCallback((node: ReactNode | null) => {
@@ -47,11 +54,8 @@ export function AppShell({
   return (
     <AppShellHeaderContext.Provider value={headerContextValue}>
       <div className="app-shell">
-        <header className="app-shell__header">
-          <div className="app-shell__header-left">
-            {leadingAction ? (
-              <div className="app-shell__leading-action">{leadingAction}</div>
-            ) : null}
+        <header className="app-shell__topbar">
+          <div className="app-shell__topbar-left">
             <button
               type="button"
               className="app-shell__brand-button"
@@ -70,26 +74,62 @@ export function AppShell({
                 <span className="app-shell__brand-tagline">QA Workspace</span>
               </span>
             </button>
+            {leadingAction ? (
+              <div className="app-shell__topbar-leading">{leadingAction}</div>
+            ) : null}
           </div>
-          <div className="app-shell__header-right">
+          <div className="app-shell__topbar-right">
             <BackgroundTaskTray />
             {isAuthenticated && (
-              <nav aria-label="계정 메뉴" className="app-shell__nav">
+              <div className="app-shell__account-actions">
                 <button type="button" className="app-shell__drive" onClick={onOpenDrive}>
                   구글 드라이브
-                </button>
-                <button type="button" className={adminClasses} onClick={onNavigateAdmin}>
-                  프롬프트 관리자
                 </button>
                 <button type="button" className="app-shell__logout" onClick={onLogout}>
                   로그아웃
                 </button>
-              </nav>
+              </div>
             )}
           </div>
         </header>
 
-        <main className="app-shell__main">{children}</main>
+        <div className="app-shell__layout">
+          {isAuthenticated ? (
+            <aside className="app-shell__sidebar" aria-label="주 메뉴">
+              <div>
+                <div className="app-shell__sidebar-heading">워크플로우</div>
+                <div className="app-shell__sidebar-links">
+                  {SIDEBAR_LINKS.map((link) => {
+                    const isActive = link.isActive(currentPath)
+                    return (
+                      <button
+                        key={link.path}
+                        type="button"
+                        className={`app-shell__sidebar-link${isActive ? ' app-shell__sidebar-link--active' : ''}`}
+                        onClick={() => navigate(link.path)}
+                      >
+                        <span className="app-shell__sidebar-link-label">{link.label}</span>
+                        <span className="app-shell__sidebar-link-description">{link.description}</span>
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+
+              <div className="app-shell__sidebar-footer">
+                <button
+                  type="button"
+                  className="app-shell__sidebar-footer-link"
+                  onClick={onNavigateAdmin}
+                >
+                  프롬프트 관리자
+                </button>
+              </div>
+            </aside>
+          ) : null}
+
+          <main className="app-shell__main">{children}</main>
+        </div>
       </div>
     </AppShellHeaderContext.Provider>
   )


### PR DESCRIPTION
## Summary
- restyle the app shell with a translucent top bar and refreshed TestMate branding
- introduce an authenticated sidebar layout that centralizes workflow navigation
- relocate the prompt manager entry to the sidebar footer and polish action button styles

## Testing
- npm run build *(fails: missing testing dependencies in the workspace)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f7c8d2a0883308c5cb7c0f57acf75)