### PR TITLE
Restore defect workflow table defaults

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2833,7 +2833,6 @@
   width: 100%;
   min-width: 900px;
   border-collapse: collapse;
-  table-layout: fixed;
 }
 
 .defect-workflow__table th,
@@ -2860,23 +2859,6 @@
   font-weight: 700;
   color: #334155;
   z-index: 1;
-}
-
-.defect-workflow__table th:nth-child(1),
-.defect-workflow__table td:nth-child(1) { width: 20%; }
-
-.defect-workflow__table th:nth-child(2),
-.defect-workflow__table td:nth-child(2) { width: 20%; }
-
-.defect-workflow__table th:nth-child(3),
-.defect-workflow__table td:nth-child(3) { width: 20%; }
-
-.defect-workflow__table th:nth-child(4),
-.defect-workflow__table td:nth-child(4) { width: 30%; }
-
-.defect-workflow__table th:nth-child(5),
-.defect-workflow__table td:nth-child(5) {
-  width: 10%;
 }
 
 .defect-workflow__cell-button {

--- a/frontend/src/components/defect-report-workflow/DefectTable.tsx
+++ b/frontend/src/components/defect-report-workflow/DefectTable.tsx
@@ -79,7 +79,7 @@ export function DefectTable({
     <section className="defect-workflow__section" aria-labelledby="defect-review">
       <div className="defect-workflow__section-heading">
         <h2 id="defect-review" className="defect-workflow__title">
-          2. 결함 검토 및 증적 첨부
+          결함 검토 및 증적 첨부
         </h2>
       </div>
       <p className="defect-workflow__helper">

--- a/frontend/src/pages/FeatureListEditPage.css
+++ b/frontend/src/pages/FeatureListEditPage.css
@@ -33,6 +33,32 @@
 
 .feature-list-editor .defect-workflow__table {
   min-width: 960px;
+  table-layout: fixed;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(1),
+.feature-list-editor .defect-workflow__table td:nth-child(1) {
+  width: 20%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(2),
+.feature-list-editor .defect-workflow__table td:nth-child(2) {
+  width: 20%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(3),
+.feature-list-editor .defect-workflow__table td:nth-child(3) {
+  width: 20%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(4),
+.feature-list-editor .defect-workflow__table td:nth-child(4) {
+  width: 30%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(5),
+.feature-list-editor .defect-workflow__table td:nth-child(5) {
+  width: 10%;
 }
 
 .feature-list-editor .defect-workflow__table td[rowspan] {


### PR DESCRIPTION
## Summary
- restore the shared defect workflow table styling so header widths flex for varied column counts
- scope fixed column widths and layout to the feature list editor to retain its UI

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb164b0ec8330b86a3a065563a98f)