### PR TITLE
Hide extra columns in security defect table

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1499,9 +1499,6 @@
 
 .project-management-page {
   --project-management-sidebar-width: 280px;
-  --project-management-viewport-height: calc(
-    100vh - (2 * var(--app-shell-main-padding-y, 0px))
-  );
   position: relative;
   display: grid;
   grid-template-columns: var(--project-management-sidebar-width) minmax(0, 1fr);
@@ -1510,8 +1507,7 @@
   width: calc(100% + (2 * var(--app-shell-main-padding-x)));
   margin: calc(-1 * var(--app-shell-main-padding-y)) calc(-1 * var(--app-shell-main-padding-x));
   background: #f8fafc;
-  height: var(--project-management-viewport-height);
-  max-height: var(--project-management-viewport-height);
+  max-height: calc(100vh - (2 * var(--app-shell-main-padding-y)));
   overflow: hidden;
   transition: grid-template-columns 0.3s ease;
 }
@@ -1748,7 +1744,6 @@
   display: flex;
   align-items: stretch;
   justify-content: center;
-  height: 100%;
 
   /* 스크롤 핵심 */
   overflow-y: auto;         /* 세로 스크롤 */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -371,7 +371,7 @@
 
 .app-shell__main {
   --app-shell-main-padding-x: clamp(1.5rem, 4vw, 3.5rem);
-  /* --app-shell-main-padding-y: clamp(2rem, 4vw, 4rem); */
+  --app-shell-main-padding-y: clamp(2rem, 4vw, 4rem);
   flex: 1;
   display: flex;
   align-items: stretch;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1499,6 +1499,9 @@
 
 .project-management-page {
   --project-management-sidebar-width: 280px;
+  --project-management-viewport-height: calc(
+    100vh - (2 * var(--app-shell-main-padding-y, 0px))
+  );
   position: relative;
   display: grid;
   grid-template-columns: var(--project-management-sidebar-width) minmax(0, 1fr);
@@ -1507,7 +1510,8 @@
   width: calc(100% + (2 * var(--app-shell-main-padding-x)));
   margin: calc(-1 * var(--app-shell-main-padding-y)) calc(-1 * var(--app-shell-main-padding-x));
   background: #f8fafc;
-  max-height: calc(100vh - (2 * var(--app-shell-main-padding-y)));
+  height: var(--project-management-viewport-height);
+  max-height: var(--project-management-viewport-height);
   overflow: hidden;
   transition: grid-template-columns 0.3s ease;
 }
@@ -1744,6 +1748,7 @@
   display: flex;
   align-items: stretch;
   justify-content: center;
+  height: 100%;
 
   /* 스크롤 핵심 */
   overflow-y: auto;         /* 세로 스크롤 */

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2833,7 +2833,6 @@
   width: 100%;
   min-width: 900px;
   border-collapse: collapse;
-  table-layout: fixed;
 }
 
 .defect-workflow__table th,
@@ -2860,23 +2859,6 @@
   font-weight: 700;
   color: #334155;
   z-index: 1;
-}
-
-.defect-workflow__table th:nth-child(1),
-.defect-workflow__table td:nth-child(1) { width: 20%; }
-
-.defect-workflow__table th:nth-child(2),
-.defect-workflow__table td:nth-child(2) { width: 20%; }
-
-.defect-workflow__table th:nth-child(3),
-.defect-workflow__table td:nth-child(3) { width: 20%; }
-
-.defect-workflow__table th:nth-child(4),
-.defect-workflow__table td:nth-child(4) { width: 30%; }
-
-.defect-workflow__table th:nth-child(5),
-.defect-workflow__table td:nth-child(5) {
-  width: 10%;
 }
 
 .defect-workflow__cell-button {

--- a/frontend/src/components/SecurityReportWorkflow.tsx
+++ b/frontend/src/components/SecurityReportWorkflow.tsx
@@ -278,7 +278,10 @@ export function SecurityReportWorkflow({
     setIsFullscreenPreview(false)
   }, [])
 
-  const columns: SecurityColumn[] = useMemo(() => SECURITY_COLUMNS, [])
+  const visibleColumns: SecurityColumn[] = useMemo(
+    () => SECURITY_COLUMNS.filter((column) => !column.hidden),
+    [],
+  )
   const showResetButton = sourceFiles.length > 0 || rows.length > 0
   const isPreviewLoading = previewStatus === 'loading'
   const isSaving = saveStatus === 'loading'
@@ -302,7 +305,7 @@ export function SecurityReportWorkflow({
       <table className="defect-workflow__table">
         <thead>
           <tr>
-            {columns.map((column) => (
+            {visibleColumns.map((column) => (
               <th key={column.key} scope="col">
                 {column.label}
               </th>
@@ -312,7 +315,7 @@ export function SecurityReportWorkflow({
         <tbody>
           {rows.map((row) => (
             <tr key={row.id}>
-              {columns.map((column) => {
+              {visibleColumns.map((column) => {
                 const value = row[column.key] ?? ''
                 const isReadOnly = readOnly || Boolean(column.readOnly)
                 return (
@@ -349,7 +352,7 @@ export function SecurityReportWorkflow({
         </tbody>
       </table>
     ),
-    [columns, handleCellChange, rows],
+    [visibleColumns, handleCellChange, rows],
   )
 
   return (

--- a/frontend/src/pages/FeatureListEditPage.css
+++ b/frontend/src/pages/FeatureListEditPage.css
@@ -33,6 +33,32 @@
 
 .feature-list-editor .defect-workflow__table {
   min-width: 960px;
+  table-layout: fixed;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(1),
+.feature-list-editor .defect-workflow__table td:nth-child(1) {
+  width: 20%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(2),
+.feature-list-editor .defect-workflow__table td:nth-child(2) {
+  width: 20%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(3),
+.feature-list-editor .defect-workflow__table td:nth-child(3) {
+  width: 20%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(4),
+.feature-list-editor .defect-workflow__table td:nth-child(4) {
+  width: 30%;
+}
+
+.feature-list-editor .defect-workflow__table th:nth-child(5),
+.feature-list-editor .defect-workflow__table td:nth-child(5) {
+  width: 10%;
 }
 
 .feature-list-editor .defect-workflow__table td[rowspan] {

--- a/frontend/src/pages/securityReportShared.ts
+++ b/frontend/src/pages/securityReportShared.ts
@@ -21,25 +21,33 @@ export interface SecurityColumn {
   backendKey: string
   input: 'text' | 'textarea'
   readOnly?: boolean
+  hidden?: boolean
 }
 
 export const SECURITY_COLUMNS: SecurityColumn[] = [
-  { key: 'order', label: '순번', backendKey: '순번', input: 'text', readOnly: true },
+  { key: 'order', label: '순번', backendKey: '순번', input: 'text', readOnly: true, hidden: true },
   {
     key: 'environment',
     label: '시험환경(OS)',
     backendKey: '시험환경 OS',
     input: 'text',
     readOnly: true,
+    hidden: true,
   },
   { key: 'summary', label: '결함요약', backendKey: '결함 요약', input: 'textarea' },
   { key: 'severity', label: '결함정도', backendKey: '결함 정도', input: 'text' },
   { key: 'frequency', label: '발생빈도', backendKey: '발생 빈도', input: 'text' },
-  { key: 'quality', label: '품질특성', backendKey: '품질 특성', input: 'text' },
+  { key: 'quality', label: '품질특성', backendKey: '품질 특성', input: 'text', hidden: true },
   { key: 'description', label: '결함 설명', backendKey: '결함 설명', input: 'textarea' },
-  { key: 'vendorResponse', label: '업체 응답', backendKey: '업체 응답', input: 'textarea' },
-  { key: 'fixStatus', label: '수정여부', backendKey: '수정여부', input: 'text' },
-  { key: 'note', label: '비고', backendKey: '비고', input: 'textarea' },
+  {
+    key: 'vendorResponse',
+    label: '업체 응답',
+    backendKey: '업체 응답',
+    input: 'textarea',
+    hidden: true,
+  },
+  { key: 'fixStatus', label: '수정여부', backendKey: '수정여부', input: 'text', hidden: true },
+  { key: 'note', label: '비고', backendKey: '비고', input: 'textarea', hidden: true },
   {
     key: 'mappingType',
     label: '매핑 유형',


### PR DESCRIPTION
## Summary
- mark security defect metadata columns as hidden in the shared column definitions
- render only visible security defect columns so the unwanted headers no longer appear

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb164b0ec8330b86a3a065563a98f)