### PR TITLE
Fix project sidebar height and responsive menu spacing

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1512,7 +1512,7 @@
   --project-management-sidebar-width: 280px;
   --project-management-available-height:
     calc(
-      var(--viewport-height) - var(--app-shell-header-height, 0px) -
+      var(--viewport-height) - var(--app-shell-header-height, 0px) +
         (2 * var(--app-shell-main-padding-y))
     );
   position: relative;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,15 @@
+:root {
+  --viewport-height: 100vh;
+}
+
+@supports (height: 100dvh) {
+  :root {
+    --viewport-height: 100dvh;
+  }
+}
+
 .app-shell {
-  min-height: 100vh;
+  min-height: var(--viewport-height);
   display: flex;
   flex-direction: column;
   background: linear-gradient(180deg, rgba(241, 245, 249, 0.82) 0%, rgba(226, 232, 240, 0.95) 100%);
@@ -377,6 +387,7 @@
   align-items: stretch;
   justify-content: center;
   padding: var(--app-shell-main-padding-y) var(--app-shell-main-padding-x);
+  min-height: 0;
 }
 
 .app-shell__footer {
@@ -1499,6 +1510,11 @@
 
 .project-management-page {
   --project-management-sidebar-width: 280px;
+  --project-management-available-height:
+    calc(
+      var(--viewport-height) - var(--app-shell-header-height, 0px) -
+        (2 * var(--app-shell-main-padding-y))
+    );
   position: relative;
   display: grid;
   grid-template-columns: var(--project-management-sidebar-width) minmax(0, 1fr);
@@ -1507,7 +1523,9 @@
   width: calc(100% + (2 * var(--app-shell-main-padding-x)));
   margin: calc(-1 * var(--app-shell-main-padding-y)) calc(-1 * var(--app-shell-main-padding-x));
   background: #f8fafc;
-  max-height: calc(100vh - (2 * var(--app-shell-main-padding-y)));
+  height: var(--project-management-available-height);
+  max-height: var(--project-management-available-height);
+  min-height: 0;
   overflow: hidden;
   transition: grid-template-columns 0.3s ease;
 }
@@ -1634,7 +1652,8 @@
   color: #e2e8f0;
   transition: transform 0.3s ease, opacity 0.3s ease;
   box-shadow: 1px 0 0 rgba(15, 23, 42, 0.4);
-  min-height: 100%;
+  min-height: 0;
+  height: 100%;
 }
 
 .project-management-page--sidebar-collapsed .project-management-sidebar {
@@ -1673,23 +1692,26 @@
 }
 
 .project-management-menu {
-  flex: 1;
+  flex: 1 1 auto;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 .project-management-menu__list {
   margin: 0;
   padding: 0;
   list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  grid-auto-rows: minmax(0, 1fr);
+  gap: clamp(0.5rem, calc(var(--project-management-available-height) / 36), 1rem);
+  height: 100%;
 }
 
 .project-management-menu__item {
   border-radius: 14px;
   overflow: hidden;
+  display: flex;
 }
 
 .project-management-menu__button {
@@ -1697,8 +1719,12 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.35rem;
-  padding: 0.9rem 1rem;
+  justify-content: center;
+  gap: clamp(0.3rem, calc(var(--project-management-available-height) / 90), 0.6rem);
+  padding:
+    clamp(0.8rem, calc(var(--project-management-available-height) / 22), 1.2rem)
+    clamp(1rem, calc(var(--project-management-available-height) / 18), 1.4rem);
+  flex: 1 1 auto;
   border: none;
   border-radius: inherit;
   background: transparent;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -380,13 +380,10 @@
 }
 
 .app-shell__main {
-  --app-shell-main-padding-x: clamp(1.5rem, 4vw, 3.5rem);
-  --app-shell-main-padding-y: clamp(2rem, 4vw, 4rem);
   flex: 1;
   display: flex;
   align-items: stretch;
   justify-content: center;
-  padding: var(--app-shell-main-padding-y) var(--app-shell-main-padding-x);
   min-height: 0;
 }
 
@@ -1511,17 +1508,13 @@
 .project-management-page {
   --project-management-sidebar-width: 280px;
   --project-management-available-height:
-    calc(
-      var(--viewport-height) - var(--app-shell-header-height, 0px) +
-        (2 * var(--app-shell-main-padding-y))
-    );
+    calc(var(--viewport-height) - var(--app-shell-header-height, 0px));
   position: relative;
   display: grid;
   grid-template-columns: var(--project-management-sidebar-width) minmax(0, 1fr);
   align-self: stretch;
   min-width: 0;
-  width: calc(100% + (2 * var(--app-shell-main-padding-x)));
-  margin: calc(-1 * var(--app-shell-main-padding-y)) calc(-1 * var(--app-shell-main-padding-x));
+  width: 100%;
   background: #f8fafc;
   height: var(--project-management-available-height);
   max-height: var(--project-management-available-height);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1547,7 +1547,7 @@
   cursor: pointer;
   box-shadow: 0 18px 32px rgba(15, 23, 42, 0.22);
   position: fixed;
-  top: 500px;
+  top: 55%;
   z-index: 3;
   --project-management-sidebar-toggle-x: 0;
   --project-management-sidebar-toggle-y: -50%;

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -82,7 +82,7 @@ export function AppShell({
 
   const shellStyle = useMemo<AppShellStyle>(
     () => ({
-      '--app-shell-header-height': `-${headerHeight}px`,
+      '--app-shell-header-height': `${headerHeight}px`,
     }),
     [headerHeight],
   )

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -1,4 +1,17 @@
-import { useCallback, useMemo, useState, type PropsWithChildren, type ReactNode } from 'react'
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type PropsWithChildren,
+  type ReactNode,
+} from 'react'
+
+type AppShellStyle = CSSProperties & {
+  '--app-shell-header-height': string
+}
 
 import { BackgroundTaskTray } from '../../components/layout/BackgroundTaskTray'
 import { AppShellHeaderContext } from './AppShellHeaderContext'
@@ -32,9 +45,32 @@ export function AppShell({
     .join(' ')
 
   const [leadingAction, setLeadingAction] = useState<ReactNode | null>(null)
+  const [headerHeight, setHeaderHeight] = useState(0)
+  const headerRef = useRef<HTMLElement | null>(null)
 
   const handleSetLeadingAction = useCallback((node: ReactNode | null) => {
     setLeadingAction(node)
+  }, [])
+
+  useLayoutEffect(() => {
+    const headerElement = headerRef.current
+    if (!headerElement) {
+      return
+    }
+
+    const updateHeaderHeight = () => {
+      const { height } = headerElement.getBoundingClientRect()
+      setHeaderHeight((prev) => (Math.abs(prev - height) > 0.5 ? height : prev))
+    }
+
+    updateHeaderHeight()
+
+    const resizeObserver = new ResizeObserver(updateHeaderHeight)
+    resizeObserver.observe(headerElement)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
   }, [])
 
   const headerContextValue = useMemo(
@@ -44,10 +80,17 @@ export function AppShell({
     [handleSetLeadingAction],
   )
 
+  const shellStyle = useMemo<AppShellStyle>(
+    () => ({
+      '--app-shell-header-height': `${headerHeight}px`,
+    }),
+    [headerHeight],
+  )
+
   return (
     <AppShellHeaderContext.Provider value={headerContextValue}>
-      <div className="app-shell">
-        <header className="app-shell__header">
+      <div className="app-shell" style={shellStyle}>
+        <header ref={headerRef} className="app-shell__header">
           <div className="app-shell__header-left">
             {leadingAction ? (
               <div className="app-shell__leading-action">{leadingAction}</div>

--- a/frontend/src/app/components/AppShell.tsx
+++ b/frontend/src/app/components/AppShell.tsx
@@ -82,7 +82,7 @@ export function AppShell({
 
   const shellStyle = useMemo<AppShellStyle>(
     () => ({
-      '--app-shell-header-height': `${headerHeight}px`,
+      '--app-shell-header-height': `-${headerHeight}px`,
     }),
     [headerHeight],
   )

--- a/frontend/src/pages/ProjectManagementPage.tsx
+++ b/frontend/src/pages/ProjectManagementPage.tsx
@@ -1349,7 +1349,6 @@ export function ProjectManagementPage({ projectId }: ProjectManagementPageProps)
                     aria-current={isActive ? 'page' : undefined}
                   >
                     <span className="project-management-menu__label">{item.label}</span>
-                    <span className="project-management-menu__helper">{item.eyebrow}</span>
                   </button>
                 </li>
               )


### PR DESCRIPTION
## Summary
- measure the app shell header height and expose it as a CSS custom property
- calculate the project management layout height from the viewport, header, and padding values so the sidebar fills the screen
- scale sidebar menu spacing and padding so buttons stay proportional to the available height across devices

## Testing
- npm run build *(fails: missing testing-related dependencies in the repository environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69100f34c2c48330b40117f409370268)